### PR TITLE
fix: Spring Boot 3.2+ compatibility, JDBC findPage, reader-map bean, case-safe count

### DIFF
--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/controller/ConfiguredReadController.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/controller/ConfiguredReadController.java
@@ -107,6 +107,9 @@ public class ConfiguredReadController {
     private Map<String, GeneralReader> getGeneralReader(Map<String, GeneralReader> readEasyGeneralReaderMap, ReadEasyConfig readEasyConfig, ApplicationContext applicationContext){
         Map<String, GeneralReader> finalReadEasyGeneralReaderMap = new HashMap<>();
 
+        if(null != readEasyGeneralReaderMap){//bean provided - use it as-is
+            finalReadEasyGeneralReaderMap.putAll(readEasyGeneralReaderMap);
+        }
         if(null == readEasyGeneralReaderMap){//bean not provided
             if(null == readEasyConfig.getGeneralReaders()){
                 readEasyConfig.setGeneralReaders(new HashMap<>());
@@ -271,7 +274,7 @@ public class ConfiguredReadController {
     @PostMapping("/export")
     public void export(@RequestParam("queryId") String queryId, @RequestBody Map<String,Object> params, @RequestParam(value = "orderby", required = false) String orderby,
                        @RequestParam(value = "orderdir", required = false) String orderdir,
-                       @RequestParam(required = false) Long countFromClient,
+                       @RequestParam(value = "countFromClient", required = false) Long countFromClient,
                        HttpServletResponse response) throws IOException {
 
         export(response, countFromClient, queryId, params, orderby, orderdir);

--- a/persistence-impls/simple-jdbc-persistence/pom.xml
+++ b/persistence-impls/simple-jdbc-persistence/pom.xml
@@ -25,6 +25,12 @@
             <version>2.0.1</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralReader.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralReader.java
@@ -49,7 +49,24 @@ public class JdbcGeneralReader implements GeneralReader<JdbcOperation, Object> {
 
     @Override
     public Page<Map<String, Object>> findPage(Page.PageRequest pageRequest, JdbcOperation query, Map<String, Object> params) {
-        throw new UnsupportedOperationException("Not yet implemented.");
+        long total = count(query, params);
+        int pageSize = Math.max(1, pageRequest.getPageSize());
+        long offset = (long) (Math.max(1, pageRequest.getPageNum()) - 1) * pageSize;
+        List<Map<String, Object>> data = getResultSetMapper()
+                .findAllRowsAsMap(paginate(query.getNativeSQL(), pageSize, offset), query.getParamsAsArr());
+        return Page.<Map<String, Object>>builder(pageRequest)
+                .totalNoOfRecords(total)
+                .data(data)
+                .build();
+    }
+
+    /**
+     * Wraps the query for one page. LIMIT/OFFSET covers PostgreSQL, MySQL,
+     * MariaDB, SQLite and H2; override for dialects that page differently
+     * (Oracle/SQL Server: OFFSET ? ROWS FETCH NEXT ? ROWS ONLY).
+     */
+    protected String paginate(String nativeSQL, int pageSize, long offset) {
+        return String.format("select * from (%s) paged_query limit %d offset %d", nativeSQL, pageSize, offset);
     }
 
     @Override
@@ -65,7 +82,9 @@ public class JdbcGeneralReader implements GeneralReader<JdbcOperation, Object> {
 
     @Override
     public long count(JdbcOperation query, Map<String, Object> params) {
-        String q = query.getNativeSQL().toLowerCase();
+        // Wrap the SQL untouched: lowercasing it corrupts case-sensitive
+        // string literals and quoted identifiers inside the query.
+        String q = query.getNativeSQL();
         String q1 = String.format("select count(*) from (%s) countingQuery", q);
         log.debug("oldQuery = {}, newQuery = {}", q, q1);
         return getResultSetMapper().count(q1, query.getParamsAsArr());

--- a/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/general/JdbcGeneralReaderTest.java
+++ b/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/general/JdbcGeneralReaderTest.java
@@ -1,0 +1,65 @@
+package lazydevs.persistence.jdbc.general;
+
+import lazydevs.persistence.reader.Page;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class JdbcGeneralReaderTest {
+
+    private static JdbcDataSource dataSource;
+    private static JdbcGeneralReader reader;
+
+    @BeforeAll
+    static void setUp() throws Exception {
+        dataSource = new JdbcDataSource();
+        dataSource.setURL("jdbc:h2:mem:readertest;DB_CLOSE_DELAY=-1");
+        try (Connection c = dataSource.getConnection(); Statement s = c.createStatement()) {
+            s.execute("create table person (id int primary key, name varchar(50))");
+            for (int i = 1; i <= 5; i++) {
+                s.execute("insert into person values (" + i + ", 'Person" + i + "')");
+            }
+            // Mixed-case literal: proves count() no longer lowercases the SQL.
+            s.execute("insert into person values (6, 'MixedCase')");
+        }
+        reader = new JdbcGeneralReader(dataSource);
+    }
+
+    @Test
+    void findPageReturnsRequestedSliceWithTotals() {
+        JdbcOperation query = JdbcOperation.nativeSql("select id, name from person order by id");
+        Page<Map<String, Object>> page = reader.findPage(
+                Page.PageRequest.builder().pageNum(2).pageSize(2).build(), query, Map.of());
+
+        assertEquals(6, page.getTotalNoOfRecords());
+        assertEquals(3, page.getTotalNoOfPages());
+        List<Map<String, Object>> data = page.getData();
+        assertEquals(2, data.size());
+        assertEquals(3, ((Number) data.get(0).get("ID")).intValue());
+        assertEquals(4, ((Number) data.get(1).get("ID")).intValue());
+    }
+
+    @Test
+    void lastPartialPageIsReturned() {
+        JdbcOperation query = JdbcOperation.nativeSql("select id from person order by id");
+        Page<Map<String, Object>> page = reader.findPage(
+                Page.PageRequest.builder().pageNum(2).pageSize(5).build(), query, Map.of());
+        assertEquals(1, page.getData().size());
+        assertEquals(6, page.getTotalNoOfRecords());
+    }
+
+    @Test
+    void countPreservesCaseSensitiveLiterals() {
+        // The old implementation lowercased the whole SQL, turning the literal
+        // into 'mixedcase' and returning 0 here.
+        JdbcOperation query = JdbcOperation.nativeSql("select id from person where name = 'MixedCase'");
+        assertEquals(1, reader.count(query, Map.of()));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -39,6 +39,19 @@
 
    <build>
         <plugins>
+            <!-- Spring Framework 6.1+ (Boot 3.2+) no longer discovers handler
+                 parameter names from bytecode via ASM, so any @RequestParam /
+                 @PathVariable without an explicit name fails at runtime with
+                 "parameter name information not available via reflection"
+                 unless the classes are compiled with -parameters. Merged on
+                 top of ifrugal-parent's compiler configuration. -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <parameters>true</parameters>
+                </configuration>
+            </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>


### PR DESCRIPTION
Four fixes found while embedding read-easy 1.0.47 in a Spring Boot 3.5.10 / GraalVM-native service backed by Postgres 16.

## 1. `/read/export` fails on Spring Boot 3.2+ (`-parameters`)

Spring Framework 6.1 removed bytecode-based parameter-name discovery, so the unnamed `@RequestParam Long countFromClient` fails at runtime:

```
IllegalArgumentException: Name for argument of type [java.lang.Long] not specified,
and parameter name information not available via reflection.
```

Fixed by compiling all modules with `-parameters` (root pom, merged over ifrugal-parent's compiler config) and naming the annotation explicitly.

## 2. Providing the `readEasyGeneralReaderMap` bean broke all lookups

`ConfiguredReadController.getGeneralReader()` only populated the result map when the autowired bean was **absent**; when present, the bean was discarded and an empty map returned, so every query failed with "No reader found register against readerId". The provided bean is now used as-is.

## 3. `JdbcGeneralReader.findPage` was unimplemented

`/read/page` threw `UnsupportedOperationException` on the JDBC backend. Implemented as count + `LIMIT/OFFSET` wrapping (covers PostgreSQL, MySQL, MariaDB, SQLite, H2), with a `protected paginate()` hook for dialects that page differently.

## 4. `count()` lowercased the whole SQL

`select count(*) from (<sql lowercased>)` corrupts case-sensitive string literals and quoted identifiers — e.g. `where name = 'MixedCase'` counted 0. The SQL is now wrapped untouched.

## Verification

- New H2 unit tests: `JdbcGeneralReaderTest` (paging slices + totals, partial last page, case-sensitive count) — 3/3 green.
- End-to-end against Postgres 16 with row-level security, via a Boot 3.5.10 servlet app embedding this branch as 1.0.48-SNAPSHOT: `/read/one`, `/read/list`, `/read/page`, `/read/count` and `/read/export` (previously 500) all pass; export streams tenant-scoped CSV.