### PR TITLE
feat(read-easy): startup query validation, dev-mode hot reload, clien…

### DIFF
--- a/app-building-blocks/read-easy/README.md
+++ b/app-building-blocks/read-easy/README.md
@@ -287,6 +287,45 @@ ${params.limit!10}
 ${.now?string('yyyy-MM-dd')}
 ```
 
+## Query Validation and Dev Tools
+
+### Startup validation
+
+Read-Easy validates query files during registration.
+The check covers YAML structure, presence of `raw`, known `readerId` values, and FreeMarker syntax of `raw` and `rowTransformer.template`.
+Template validation is parse-only: it never renders the template, so queries referencing request-time variables such as `${params.customerId}` or `${request.userId}` validate cleanly.
+
+```yaml
+readeasy:
+  validation:
+    enabled: true           # validate query files at startup (default: true)
+    failOnError: false      # abort startup on errors; false logs warnings (default: false)
+    validateTemplates: true # compile-check FreeMarker syntax (default: true)
+```
+
+Set `failOnError: true` in development to fail fast on broken query files.
+The default keeps existing applications booting and reports problems as warnings.
+
+### Hot reload (dev mode)
+
+With dev tools enabled, changed query files are re-registered without a restart.
+Only `file:` resources can be watched; classpath resources inside a JAR are skipped with a warning.
+An invalid save is rejected and the previous queries stay active.
+Reloading one file only replaces the queries that file contributed, even when several files share a namespace.
+
+```yaml
+readeasy:
+  devtools:
+    enabled: true           # default: false; only enable in development
+    watchIntervalMs: 2000   # file poll interval
+    validateOnReload: true  # validate a changed file before applying it
+```
+
+### Runtime template errors
+
+A query that fails to render or parse at request time returns HTTP 400 with a short, client-safe message naming the query and the missing variable.
+The full template and rendered query are written to the server log only, never to the HTTP response.
+
 ## Working with Different Databases
 
 ### JDBC (SQL Databases)

--- a/app-building-blocks/read-easy/pom.xml
+++ b/app-building-blocks/read-easy/pom.xml
@@ -25,5 +25,12 @@
             <artifactId>dyna-beans-injector</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
+
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <version>5.10.2</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/beans/ReadEasyAutoConfiguration.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/beans/ReadEasyAutoConfiguration.java
@@ -2,12 +2,32 @@ package lazydevs.readeasy.beans;
 
 import lazydevs.readeasy.config.ReadEasyConfig;
 import lazydevs.readeasy.controller.ConfiguredReadController;
+import lazydevs.readeasy.devtools.DevModeQueryReloader;
+import lazydevs.readeasy.registry.QueryRegistry;
 import lazydevs.services.basic.validation.ParamValidator;
+import lazydevs.springhelpers.dynabeans.DynaBeansAutoConfiguration;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.io.ResourceLoader;
 
 /**
+ * Auto-configuration for the Read-Easy framework.
+ *
+ * <p>Bootstraps:</p>
+ * <ul>
+ *   <li>{@link ConfiguredReadController} - the /read/* endpoints</li>
+ *   <li>{@link QueryRegistry} - the single owner of registered queries</li>
+ *   <li>{@link DevModeQueryReloader} - hot reload, only when {@code readeasy.devtools.enabled=true}</li>
+ *   <li>{@link ParamValidator} - request parameter validation</li>
+ * </ul>
+ *
+ * <p>Registered for Spring Boot 3 via
+ * {@code META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports}
+ * (the legacy {@code spring.factories} entry is kept for Boot 2 consumers).</p>
+ *
  * @author Abhijeet Rai
  */
 @Configuration
@@ -15,4 +35,16 @@ import org.springframework.context.annotation.Import;
 @Import({ConfiguredReadController.class, ParamValidator.class})
 public class ReadEasyAutoConfiguration {
 
+    @Bean
+    public QueryRegistry readEasyQueryRegistry(DynaBeansAutoConfiguration dynaBeansAutoConfiguration) {
+        return new QueryRegistry(dynaBeansAutoConfiguration);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "readeasy.devtools.enabled", havingValue = "true")
+    public DevModeQueryReloader devModeQueryReloader(ReadEasyConfig readEasyConfig,
+                                                    ResourceLoader resourceLoader,
+                                                    QueryRegistry queryRegistry) {
+        return new DevModeQueryReloader(readEasyConfig, resourceLoader, queryRegistry);
+    }
 }

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/config/ReadEasyConfig.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/config/ReadEasyConfig.java
@@ -165,6 +165,64 @@ public class ReadEasyConfig{
      */
     private Map<Operation, Map<String, Object>> operationInstruction = new HashMap<>();
 
+    /**
+     * Startup-time query validation settings.
+     */
+    private ValidationConfig validation = new ValidationConfig();
+
+    /**
+     * Development tools (hot reload) settings.
+     */
+    private DevtoolsConfig devtools = new DevtoolsConfig();
+
+    /**
+     * Configuration for startup-time query validation.
+     *
+     * <p>Template validation is a FreeMarker parse-only check: it catches syntax
+     * errors (unclosed directives, malformed expressions) but never renders the
+     * template, so queries referencing request-specific variables validate cleanly.</p>
+     *
+     * <p>Example:</p>
+     * <pre>{@code
+     * readeasy:
+     *   validation:
+     *     enabled: true           # validate query files at startup (default: true)
+     *     failOnError: false      # abort startup on errors; false logs warnings (default: false)
+     *     validateTemplates: true # compile-check FreeMarker syntax (default: true)
+     * }</pre>
+     */
+    @Getter @Setter @ToString
+    public static class ValidationConfig {
+        /** Validate query YAML files during registration. */
+        private boolean enabled = true;
+        /** Abort application startup when validation errors are found; when false, errors are logged as warnings. */
+        private boolean failOnError = false;
+        /** Compile-check FreeMarker syntax of 'raw' and rowTransformer templates. */
+        private boolean validateTemplates = true;
+    }
+
+    /**
+     * Configuration for development tools. Only enable in development environments.
+     *
+     * <p>Example:</p>
+     * <pre>{@code
+     * readeasy:
+     *   devtools:
+     *     enabled: true           # hot reload of query files (default: false)
+     *     watchIntervalMs: 2000   # file poll interval (default: 2000)
+     *     validateOnReload: true  # validate a changed file before applying it (default: true)
+     * }</pre>
+     */
+    @Getter @Setter @ToString
+    public static class DevtoolsConfig {
+        /** Enable hot reload of query YAML files. */
+        private boolean enabled = false;
+        /** Interval in milliseconds between file modification checks. */
+        private long watchIntervalMs = 2000;
+        /** Validate a changed file before applying it; an invalid file keeps the previous queries active. */
+        private boolean validateOnReload = true;
+    }
+
 
     /**
      * Container class for query YAML file structure.

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/controller/ConfiguredReadController.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/controller/ConfiguredReadController.java
@@ -2,7 +2,6 @@ package lazydevs.readeasy.controller;
 
 
 import lazydevs.mapper.utils.BatchIterator;
-import lazydevs.mapper.utils.SerDe;
 import lazydevs.mapper.utils.engine.TemplateEngine;
 import lazydevs.mapper.utils.reflection.ReflectionUtils;
 import lazydevs.persistence.reader.GeneralReader;
@@ -10,7 +9,10 @@ import lazydevs.persistence.reader.GeneralTransformer;
 import lazydevs.persistence.reader.Page;
 import lazydevs.readeasy.config.ReadEasyConfig;
 import lazydevs.readeasy.config.ReadEasyConfig.Query;
-import lazydevs.readeasy.config.ReadEasyConfig.QueryWithDynaBeans;
+import lazydevs.readeasy.config.ReadEasyConfig.ValidationConfig;
+import lazydevs.readeasy.registry.QueryRegistry;
+import lazydevs.readeasy.validation.QueryTemplateException;
+import lazydevs.readeasy.validation.QueryValidator;
 import lazydevs.services.basic.exception.RESTException;
 import lazydevs.services.basic.exception.ValidationException;
 import lazydevs.services.basic.validation.ParamValidator;
@@ -68,7 +70,8 @@ import static org.springframework.util.StringUtils.hasText;
 @Slf4j
 public class ConfiguredReadController {
 
-    private Map<String, Query> queries;
+    @Autowired private QueryRegistry queryRegistry;
+    private final QueryValidator queryValidator = new QueryValidator();
     @Autowired DynaBeansAutoConfiguration dynaBeansAutoConfiguration;
     @Autowired private ResourceLoader resourceLoader;
     @Autowired(required = false) @Qualifier("readEasyGeneralReaderMap") @Getter private Map<String, GeneralReader> readEasyGeneralReaderMap;
@@ -85,17 +88,24 @@ public class ConfiguredReadController {
     public void init() throws IOException {
         log.info(readInputStreamAsString(applicationContext.getResource(bannerPath).getInputStream()));
         this.readEasyGeneralReaderMap = getGeneralReader(readEasyGeneralReaderMap, readEasyConfig, applicationContext);
-        queries = new HashMap<>();
+        Set<String> availableReaderIds = this.readEasyGeneralReaderMap.keySet();
+        ValidationConfig validation = readEasyConfig.getValidation();
         readEasyConfig.getQueryFiles().forEach((namespace, filePaths)-> {
-            filePaths.stream().forEach(filePath -> {
+            filePaths.forEach(filePath -> {
                 log.info("Registering ReadEasy Config from file = {} with namespace = {}", filePath, namespace);
                 try {
-                    register(namespace, resourceLoader.getResource(filePath).getInputStream());
+                    String content = readInputStreamAsString(resourceLoader.getResource(filePath).getInputStream());
+                    if (validation.isEnabled()) {
+                        queryValidator.validateAndThrow(namespace, filePath, content, availableReaderIds,
+                                validation.isValidateTemplates(), validation.isFailOnError());
+                    }
+                    queryRegistry.register(namespace, filePath, content);
                 } catch (IOException e) {
                     throw new IllegalStateException("Unable to Start read-easy engine. Error while registering file ="+filePath, e);
                 }
             });
         });
+        log.info("Read-Easy initialized with {} queries", queryRegistry.size());
         if(null != readEasyConfig.getRequestContextSupplierInit()) {
             this.requestContextSupplier = ReflectionUtils.getInterfaceReference(readEasyConfig.getRequestContextSupplierInit(), Supplier.class, (s) -> applicationContext.getBean(s), environment::getProperty);
         }
@@ -128,10 +138,14 @@ public class ConfiguredReadController {
         return finalReadEasyGeneralReaderMap;
     }
 
-    private void register(String namespace, InputStream inputStream){
-        QueryWithDynaBeans queryWithDynaBeans = SerDe.YAML.deserialize(readInputStreamAsString(inputStream), QueryWithDynaBeans.class);
-        dynaBeansAutoConfiguration.initializeAndInject(namespace, queryWithDynaBeans.getDynaBeans());
-        queryWithDynaBeans.getQueries().forEach((queryId, query) -> queries.put(namespace+"."+queryId, query));
+    private void register(String namespace, String sourceKey, InputStream inputStream){
+        String content = readInputStreamAsString(inputStream);
+        ValidationConfig validation = readEasyConfig.getValidation();
+        if (validation.isEnabled()) {
+            queryValidator.validateAndThrow(namespace, sourceKey, content, readEasyGeneralReaderMap.keySet(),
+                    validation.isValidateTemplates(), true);
+        }
+        queryRegistry.register(namespace, sourceKey, content);
     }
 
     private Map<String, Object> decorateDatapoints(Map<String, Object> data, Map<String, Object> params){
@@ -162,12 +176,30 @@ public class ConfiguredReadController {
             params.put("sort", sort);
         }
 
-        String transformedQuery = TemplateEngine.getInstance().generate(query.getRaw(), decorateDatapoints(params, null));
-        return query.getRawFormat().deserialize(transformedQuery, getGeneralReader(query.getReaderId()).getQueryType());
+        GeneralReader generalReader = getGeneralReader(query.getReaderId());
+
+        String transformedQuery;
+        try {
+            transformedQuery = TemplateEngine.getInstance().generate(query.getRaw(), decorateDatapoints(params, null));
+        } catch (Exception e) {
+            log.error("Template rendering failed for queryId = {}. Template:\n{}", queryId, query.getRaw(), e);
+            throw new QueryTemplateException(queryId,
+                    "Query '" + queryId + "' failed to render: " + QueryTemplateException.summarize(e)
+                            + ". Check that all required parameters are provided.", e);
+        }
+        try {
+            return query.getRawFormat().deserialize(transformedQuery, generalReader.getQueryType());
+        } catch (Exception e) {
+            log.error("Rendered query for queryId = {} is not valid {}. Rendered query:\n{}",
+                    queryId, query.getRawFormat(), transformedQuery, e);
+            throw new QueryTemplateException(queryId,
+                    "Query '" + queryId + "' rendered to invalid " + query.getRawFormat()
+                            + ". Check the query definition and the provided parameters.", e);
+        }
     }
 
     private Query getRegisteredQuery(String queryId) {
-        Query query = queries.get(queryId);
+        Query query = queryRegistry.get(queryId);
         if(null == query){
             throw new ValidationException("No query found registered for queryId = "+queryId);
         }
@@ -209,7 +241,8 @@ public class ConfiguredReadController {
     @PostMapping(value = "/register", consumes = MULTIPART_FORM_DATA_VALUE)
     public void register(@RequestPart(name = "namespace", required = false) String namespace,
                          @RequestPart(name = "registrationFile") MultipartFile registrationFile) throws IOException {
-        register(namespace, registrationFile.getInputStream());
+        register(namespace, "upload:" + namespace + ":" + registrationFile.getOriginalFilename(),
+                registrationFile.getInputStream());
     }
 
     @PostMapping("/one")

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/devtools/DevModeQueryReloader.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/devtools/DevModeQueryReloader.java
@@ -1,0 +1,160 @@
+package lazydevs.readeasy.devtools;
+
+import lazydevs.readeasy.config.ReadEasyConfig;
+import lazydevs.readeasy.config.ReadEasyConfig.DevtoolsConfig;
+import lazydevs.readeasy.registry.QueryRegistry;
+import lazydevs.readeasy.validation.QueryValidator;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.Resource;
+import org.springframework.core.io.ResourceLoader;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+import static lazydevs.mapper.utils.file.FileUtils.readInputStreamAsString;
+
+/**
+ * Development-mode hot reload of query YAML files.
+ *
+ * <p>Polls the configured query files on a dedicated daemon thread and, when a
+ * file's lastModified changes, re-registers that file through the shared
+ * {@link QueryRegistry} - the same path startup registration uses. Because the
+ * registry replaces queries per source file, reloading one file never touches
+ * queries contributed by other files of the same namespace, and readers always
+ * see a complete snapshot.</p>
+ *
+ * <p>Uses its own {@link ScheduledExecutorService} instead of Spring scheduling,
+ * so enabling it does not switch on {@code @EnableScheduling} (and thereby other
+ * dormant {@code @Scheduled} methods) in the host application.</p>
+ *
+ * <h2>Configuration</h2>
+ * <pre>{@code
+ * readeasy:
+ *   devtools:
+ *     enabled: true            # default: false; only enable in development
+ *     watchIntervalMs: 2000    # file poll interval
+ *     validateOnReload: true   # validate before applying a changed file
+ * }</pre>
+ *
+ * <p>Only file-system resources can be watched; classpath resources inside a JAR
+ * are logged and skipped.</p>
+ *
+ * @author Abhijeet Rai
+ */
+@Slf4j
+public class DevModeQueryReloader {
+
+    private final ReadEasyConfig readEasyConfig;
+    private final ResourceLoader resourceLoader;
+    private final QueryRegistry queryRegistry;
+    private final QueryValidator queryValidator = new QueryValidator();
+
+    private final Map<String, Long> fileModifiedTimes = new ConcurrentHashMap<>();
+    private ScheduledExecutorService executor;
+
+    public DevModeQueryReloader(ReadEasyConfig readEasyConfig, ResourceLoader resourceLoader,
+                                QueryRegistry queryRegistry) {
+        this.readEasyConfig = readEasyConfig;
+        this.resourceLoader = resourceLoader;
+        this.queryRegistry = queryRegistry;
+    }
+
+    @PostConstruct
+    public void init() {
+        DevtoolsConfig devtools = readEasyConfig.getDevtools();
+        log.info("READ-EASY DEV MODE ENABLED - hot reload active for query YAML files (interval = {} ms)",
+                devtools.getWatchIntervalMs());
+        recordInitialTimestamps();
+        executor = Executors.newSingleThreadScheduledExecutor(runnable -> {
+            Thread thread = new Thread(runnable, "read-easy-devtools");
+            thread.setDaemon(true);
+            return thread;
+        });
+        executor.scheduleWithFixedDelay(this::checkForChanges,
+                devtools.getWatchIntervalMs(), devtools.getWatchIntervalMs(), TimeUnit.MILLISECONDS);
+    }
+
+    @PreDestroy
+    public void shutdown() {
+        if (null != executor) {
+            executor.shutdownNow();
+        }
+    }
+
+    void recordInitialTimestamps() {
+        forEachQueryFile((namespace, filePath) -> {
+            try {
+                Resource resource = resourceLoader.getResource(filePath);
+                if (resource.exists() && resource.isFile()) {
+                    fileModifiedTimes.put(filePath, resource.getFile().lastModified());
+                    log.info("Watching for changes: {} (namespace = {})", filePath, namespace);
+                } else {
+                    log.warn("Cannot watch non-file resource: {}. Hot reload requires file: resources.", filePath);
+                }
+            } catch (IOException e) {
+                log.warn("Cannot monitor file {}: {}", filePath, e.getMessage());
+            }
+        });
+    }
+
+    void checkForChanges() {
+        forEachQueryFile((namespace, filePath) -> {
+            try {
+                checkAndReloadFile(namespace, filePath);
+            } catch (Exception e) {
+                log.error("Error checking file {}: {}", filePath, e.getMessage());
+            }
+        });
+    }
+
+    private void checkAndReloadFile(String namespace, String filePath) throws IOException {
+        Resource resource = resourceLoader.getResource(filePath);
+        if (!resource.exists() || !resource.isFile()) {
+            return;
+        }
+        long currentModified = resource.getFile().lastModified();
+        Long lastModified = fileModifiedTimes.get(filePath);
+        if (null != lastModified && currentModified <= lastModified) {
+            return;
+        }
+        log.info("File change detected: {}", filePath);
+        try {
+            reloadQueryFile(namespace, filePath, resource);
+            fileModifiedTimes.put(filePath, currentModified);
+            log.info("Successfully reloaded queries from: {}", filePath);
+        } catch (Exception e) {
+            // Record the timestamp anyway so a broken save is reported once, not every tick.
+            fileModifiedTimes.put(filePath, currentModified);
+            log.error("Failed to reload {}. Previous queries remain active; fix the file and save again. Cause: {}",
+                    filePath, e.getMessage());
+        }
+    }
+
+    private void reloadQueryFile(String namespace, String filePath, Resource resource) throws IOException {
+        String content = readInputStreamAsString(resource.getInputStream());
+        if (readEasyConfig.getDevtools().isValidateOnReload()) {
+            // Reader ids are not known here; the reader check happens at request time.
+            queryValidator.validateAndThrow(namespace, filePath, content, Collections.emptySet(),
+                    readEasyConfig.getValidation().isValidateTemplates(), true);
+        }
+        int count = queryRegistry.register(namespace, filePath, content);
+        log.info("Reloaded {} queries from namespace '{}'", count, namespace);
+    }
+
+    private void forEachQueryFile(QueryFileConsumer consumer) {
+        readEasyConfig.getQueryFiles().forEach((namespace, filePaths) ->
+                filePaths.forEach(filePath -> consumer.accept(namespace, filePath)));
+    }
+
+    @FunctionalInterface
+    private interface QueryFileConsumer {
+        void accept(String namespace, String filePath);
+    }
+}

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/registry/QueryRegistry.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/registry/QueryRegistry.java
@@ -1,0 +1,88 @@
+package lazydevs.readeasy.registry;
+
+import lazydevs.mapper.utils.SerDe;
+import lazydevs.readeasy.config.ReadEasyConfig.Query;
+import lazydevs.readeasy.config.ReadEasyConfig.QueryWithDynaBeans;
+import lazydevs.springhelpers.dynabeans.DynaBeansAutoConfiguration;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * The single owner of registered queries. Both startup registration
+ * ({@code ConfiguredReadController#init}) and dev-mode hot reload
+ * ({@code DevModeQueryReloader}) go through {@link #register}, so registration
+ * semantics cannot drift between the two paths.
+ *
+ * <p>Thread safety: writers replace the whole map under a lock (copy-on-write)
+ * and publish it through a volatile reference, so request threads always read a
+ * complete, immutable snapshot - never a half-updated map.</p>
+ *
+ * <p>Each registration is keyed by a source (normally the file path). Re-registering
+ * a source replaces only the queries that source contributed, so a namespace fed by
+ * several files keeps the other files' queries intact when one file is reloaded.</p>
+ *
+ * @author Abhijeet Rai
+ */
+@Slf4j
+public class QueryRegistry {
+
+    private final DynaBeansAutoConfiguration dynaBeansAutoConfiguration;
+
+    private volatile Map<String, Query> queries = Collections.emptyMap();
+
+    /** source key (file path or upload key) -> query ids contributed by that source. Guarded by writeLock. */
+    private final Map<String, Set<String>> queryIdsBySource = new HashMap<>();
+    private final Object writeLock = new Object();
+
+    public QueryRegistry(DynaBeansAutoConfiguration dynaBeansAutoConfiguration) {
+        this.dynaBeansAutoConfiguration = dynaBeansAutoConfiguration;
+    }
+
+    /**
+     * Parses the YAML content and registers its queries under
+     * {@code namespace.queryName}, replacing whatever this source registered before.
+     *
+     * @param namespace the namespace the file belongs to
+     * @param sourceKey identity of the content's origin (file path or upload key)
+     * @param content   the query YAML content
+     * @return number of queries registered from this content
+     */
+    public int register(String namespace, String sourceKey, String content) {
+        QueryWithDynaBeans queryWithDynaBeans = SerDe.YAML.deserialize(content, QueryWithDynaBeans.class);
+        if (null != dynaBeansAutoConfiguration) {
+            dynaBeansAutoConfiguration.initializeAndInject(namespace, queryWithDynaBeans.getDynaBeans());
+        }
+        Map<String, Query> newQueries = queryWithDynaBeans.getQueries();
+        if (null == newQueries) {
+            newQueries = Collections.emptyMap();
+        }
+        synchronized (writeLock) {
+            Map<String, Query> next = new HashMap<>(queries);
+            Set<String> previousIds = queryIdsBySource.getOrDefault(sourceKey, Collections.emptySet());
+            previousIds.forEach(next::remove);
+            Set<String> newIds = new LinkedHashSet<>();
+            newQueries.forEach((queryId, query) -> {
+                String fullQueryId = namespace + "." + queryId;
+                next.put(fullQueryId, query);
+                newIds.add(fullQueryId);
+            });
+            queryIdsBySource.put(sourceKey, newIds);
+            queries = Collections.unmodifiableMap(next);
+            log.debug("Registered {} queries from source = {} (namespace = {})", newIds.size(), sourceKey, namespace);
+            return newIds.size();
+        }
+    }
+
+    public Query get(String queryId) {
+        return queries.get(queryId);
+    }
+
+    public int size() {
+        return queries.size();
+    }
+}

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/validation/QueryTemplateException.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/validation/QueryTemplateException.java
@@ -1,0 +1,51 @@
+package lazydevs.readeasy.validation;
+
+import lazydevs.services.basic.exception.RESTException;
+import lombok.Getter;
+
+import java.net.HttpURLConnection;
+
+/**
+ * Thrown when a registered query fails to render or parse at request time.
+ * Extends RESTException so the shared handler maps it to HTTP 400 (these
+ * failures are typically caused by the caller's parameters).
+ *
+ * <p>The message is intentionally client-safe: it names the query and the kind
+ * of failure but never embeds the query template or the rendered query text.
+ * Full details belong in the server log at the throw site.</p>
+ *
+ * @author Abhijeet Rai
+ */
+public class QueryTemplateException extends RESTException {
+
+    private static final int MAX_CAUSE_SUMMARY_LENGTH = 200;
+
+    @Getter
+    private final String queryId;
+
+    public QueryTemplateException(String queryId, String clientSafeMessage, Throwable cause) {
+        super(clientSafeMessage, cause, HttpURLConnection.HTTP_BAD_REQUEST);
+        this.queryId = queryId;
+    }
+
+    /**
+     * A short, single-line summary of the root cause, safe to include in a client
+     * message: FreeMarker's variable-reference errors name the missing variable
+     * (useful to the caller) without exposing the query text.
+     */
+    public static String summarize(Throwable cause) {
+        Throwable root = cause;
+        while (null != root.getCause()) {
+            root = root.getCause();
+        }
+        String message = root.getMessage();
+        if (null == message || message.isEmpty()) {
+            return root.getClass().getSimpleName();
+        }
+        message = message.replaceAll("\\s+", " ").trim();
+        if (message.length() > MAX_CAUSE_SUMMARY_LENGTH) {
+            message = message.substring(0, MAX_CAUSE_SUMMARY_LENGTH) + "...";
+        }
+        return message;
+    }
+}

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/validation/QueryValidationException.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/validation/QueryValidationException.java
@@ -1,0 +1,53 @@
+package lazydevs.readeasy.validation;
+
+import lazydevs.services.basic.exception.RESTException;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Value;
+
+import java.net.HttpURLConnection;
+import java.util.List;
+
+/**
+ * Thrown when query YAML validation fails. At startup (with failOnError enabled)
+ * it aborts the boot with a readable error listing; thrown from the admin
+ * /read/register endpoint it maps to HTTP 400 via the shared RESTException handling.
+ *
+ * @author Abhijeet Rai
+ */
+public class QueryValidationException extends RESTException {
+
+    @Getter
+    private final List<ValidationError> errors;
+
+    public QueryValidationException(String message, List<ValidationError> errors) {
+        super(formatMessage(message, errors), HttpURLConnection.HTTP_BAD_REQUEST);
+        this.errors = List.copyOf(errors);
+    }
+
+    private static String formatMessage(String message, List<ValidationError> errors) {
+        StringBuilder sb = new StringBuilder(message);
+        sb.append("\nVALIDATION ERRORS (").append(errors.size()).append(" found):\n");
+        for (int i = 0; i < errors.size(); i++) {
+            ValidationError error = errors.get(i);
+            sb.append(String.format("%d. [%s] %s%n", i + 1, error.getErrorType(), error.getQueryId()));
+            sb.append("   Location: ").append(error.getLocation()).append("\n");
+            sb.append("   Problem:  ").append(error.getMessage()).append("\n");
+            if (null != error.getSuggestion()) {
+                sb.append("   Fix:      ").append(error.getSuggestion()).append("\n");
+            }
+        }
+        return sb.toString();
+    }
+
+    /** A single validation problem with enough context to locate and fix it. */
+    @Value
+    @Builder
+    public static class ValidationError {
+        String queryId;
+        String location;
+        String errorType;
+        String message;
+        String suggestion;
+    }
+}

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/validation/QueryValidator.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/validation/QueryValidator.java
@@ -1,0 +1,150 @@
+package lazydevs.readeasy.validation;
+
+import lazydevs.mapper.utils.SerDe;
+import lazydevs.mapper.utils.engine.TemplateEngine;
+import lazydevs.readeasy.config.ReadEasyConfig.Query;
+import lazydevs.readeasy.config.ReadEasyConfig.QueryWithDynaBeans;
+import lazydevs.readeasy.validation.QueryValidationException.ValidationError;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Validates query YAML files. Stateless; safe to instantiate anywhere.
+ *
+ * <p>Checks performed:</p>
+ * <ul>
+ *   <li>YAML parses into the query file structure</li>
+ *   <li>at least one query is defined</li>
+ *   <li>every query has a non-empty {@code raw} template</li>
+ *   <li>{@code readerId} matches a configured reader (when the reader set is known)</li>
+ *   <li>FreeMarker syntax of {@code raw} and {@code rowTransformer.template} compiles</li>
+ * </ul>
+ *
+ * <p>Template validation is a parse-only check ({@link TemplateEngine#validateSyntax}):
+ * it never renders the template, so queries referencing request-specific variables
+ * (e.g. {@code ${params.customerId}} or {@code ${request.userId}}) validate cleanly.
+ * Whether the rendered output parses as the reader's query type depends on runtime
+ * data and is deliberately not checked here.</p>
+ *
+ * @author Abhijeet Rai
+ */
+@Slf4j
+public class QueryValidator {
+
+    /**
+     * Validates one query file's content and returns the problems found.
+     *
+     * @param namespace          namespace the file is registered under
+     * @param filePath           file path, used only for error locations
+     * @param content            the YAML content
+     * @param availableReaderIds configured reader ids; pass null or empty to skip the reader check
+     * @param validateTemplates  whether to compile-check FreeMarker templates
+     * @return validation errors, empty when the file is valid
+     */
+    public List<ValidationError> validateQueryFile(String namespace, String filePath, String content,
+                                                   Set<String> availableReaderIds, boolean validateTemplates) {
+        List<ValidationError> errors = new ArrayList<>();
+
+        QueryWithDynaBeans queryWithDynaBeans;
+        try {
+            queryWithDynaBeans = SerDe.YAML.deserialize(content, QueryWithDynaBeans.class);
+        } catch (Exception e) {
+            errors.add(ValidationError.builder()
+                    .queryId(namespace + ".*")
+                    .location(filePath)
+                    .errorType("YAML_SYNTAX")
+                    .message("Failed to parse YAML: " + QueryTemplateException.summarize(e))
+                    .suggestion("Check YAML syntax - proper indentation, no tab characters")
+                    .build());
+            return errors;
+        }
+
+        if (null == queryWithDynaBeans.getQueries() || queryWithDynaBeans.getQueries().isEmpty()) {
+            errors.add(ValidationError.builder()
+                    .queryId(namespace + ".*")
+                    .location(filePath)
+                    .errorType("MISSING_QUERIES")
+                    .message("No queries defined in file")
+                    .suggestion("Add a 'queries:' section with at least one query definition")
+                    .build());
+            return errors;
+        }
+
+        queryWithDynaBeans.getQueries().forEach((queryName, query) ->
+                validateQuery(namespace + "." + queryName, filePath + " -> queries." + queryName,
+                        query, availableReaderIds, validateTemplates, errors));
+        return errors;
+    }
+
+    private void validateQuery(String queryId, String location, Query query,
+                               Set<String> availableReaderIds, boolean validateTemplates,
+                               List<ValidationError> errors) {
+        if (null == query.getRaw() || query.getRaw().trim().isEmpty()) {
+            errors.add(ValidationError.builder()
+                    .queryId(queryId)
+                    .location(location)
+                    .errorType("MISSING_RAW")
+                    .message("Query 'raw' field is required but missing or empty")
+                    .suggestion("Add a 'raw:' field with the query template")
+                    .build());
+            return;
+        }
+
+        if (null != availableReaderIds && !availableReaderIds.isEmpty()
+                && !availableReaderIds.contains(query.getReaderId())) {
+            errors.add(ValidationError.builder()
+                    .queryId(queryId)
+                    .location(location + ".readerId")
+                    .errorType("INVALID_READER")
+                    .message("Reader ID '" + query.getReaderId() + "' is not configured")
+                    .suggestion("Available readers: " + availableReaderIds
+                            + ". Check 'readeasy.generalReaders' in application.yml")
+                    .build());
+        }
+
+        if (validateTemplates) {
+            validateTemplateSyntax(queryId, location + ".raw", query.getRaw(), errors);
+            if (null != query.getRowTransformer() && null != query.getRowTransformer().getTemplate()) {
+                validateTemplateSyntax(queryId + ".rowTransformer", location + ".rowTransformer.template",
+                        query.getRowTransformer().getTemplate(), errors);
+            }
+        }
+    }
+
+    private void validateTemplateSyntax(String queryId, String location, String template,
+                                        List<ValidationError> errors) {
+        try {
+            TemplateEngine.getInstance().validateSyntax(template);
+        } catch (Exception e) {
+            errors.add(ValidationError.builder()
+                    .queryId(queryId)
+                    .location(location)
+                    .errorType("TEMPLATE_SYNTAX")
+                    .message("FreeMarker syntax error: " + QueryTemplateException.summarize(e))
+                    .suggestion("Fix the directive/expression syntax; every <#if>/<#list> needs a matching closer")
+                    .build());
+        }
+    }
+
+    /**
+     * Validates and either throws (failOnError) or logs the problems as warnings.
+     */
+    public void validateAndThrow(String namespace, String filePath, String content,
+                                 Set<String> availableReaderIds, boolean validateTemplates,
+                                 boolean failOnError) {
+        List<ValidationError> errors = validateQueryFile(namespace, filePath, content,
+                availableReaderIds, validateTemplates);
+        if (errors.isEmpty()) {
+            return;
+        }
+        if (failOnError) {
+            throw new QueryValidationException("Validation failed for query file: " + filePath, errors);
+        }
+        log.warn("Query validation found {} issue(s) in {}:", errors.size(), filePath);
+        errors.forEach(error -> log.warn("  - [{}] {}: {}",
+                error.getErrorType(), error.getQueryId(), error.getMessage()));
+    }
+}

--- a/app-building-blocks/read-easy/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/app-building-blocks/read-easy/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,0 +1,1 @@
+lazydevs.readeasy.beans.ReadEasyAutoConfiguration

--- a/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/devtools/DevModeQueryReloaderTest.java
+++ b/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/devtools/DevModeQueryReloaderTest.java
@@ -1,0 +1,131 @@
+package lazydevs.readeasy.devtools;
+
+import lazydevs.readeasy.config.ReadEasyConfig;
+import lazydevs.readeasy.registry.QueryRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.core.io.DefaultResourceLoader;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class DevModeQueryReloaderTest {
+
+    private static final String INITIAL = """
+            queries:
+              byId:
+                raw: '{"nativeSQL": "SELECT * FROM users WHERE id = :id"}'
+            """;
+
+    private static final String UPDATED = """
+            queries:
+              byId:
+                raw: '{"nativeSQL": "SELECT id FROM users WHERE id = :id"}'
+              all:
+                raw: '{"nativeSQL": "SELECT * FROM users"}'
+            """;
+
+    private static final String INVALID = """
+            queries:
+              broken:
+                readerId: default
+            """;
+
+    @TempDir
+    Path tempDir;
+
+    private Path queryFile;
+    private ReadEasyConfig config;
+    private QueryRegistry registry;
+    private DevModeQueryReloader reloader;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        queryFile = tempDir.resolve("users.yaml");
+        Files.writeString(queryFile, INITIAL);
+
+        config = new ReadEasyConfig();
+        config.getQueryFiles().put("users", List.of("file:" + queryFile));
+        config.getDevtools().setEnabled(true);
+
+        registry = new QueryRegistry(null);
+        registry.register("users", "file:" + queryFile, INITIAL);
+
+        reloader = new DevModeQueryReloader(config, new DefaultResourceLoader(), registry);
+        reloader.recordInitialTimestamps();
+    }
+
+    private void touch() throws IOException {
+        // Advance mtime well past the recorded value; second-granularity file systems
+        // would otherwise hide a fast rewrite.
+        Files.setLastModifiedTime(queryFile,
+                java.nio.file.attribute.FileTime.fromMillis(System.currentTimeMillis() + 10_000));
+    }
+
+    @Test
+    void unchangedFileDoesNothing() {
+        reloader.checkForChanges();
+        assertEquals(1, registry.size());
+    }
+
+    @Test
+    void changedFileIsReloaded() throws IOException {
+        Files.writeString(queryFile, UPDATED);
+        touch();
+        reloader.checkForChanges();
+        assertEquals(2, registry.size());
+        assertNotNull(registry.get("users.all"));
+    }
+
+    @Test
+    void invalidChangeKeepsPreviousQueriesActive() throws IOException {
+        Files.writeString(queryFile, INVALID);
+        touch();
+        reloader.checkForChanges();
+        assertEquals(1, registry.size());
+        assertNotNull(registry.get("users.byId"), "previous queries must survive an invalid save");
+        assertNull(registry.get("users.broken"));
+    }
+
+    @Test
+    void queryRemovedFromFileIsRemovedOnReload() throws IOException {
+        Files.writeString(queryFile, UPDATED);
+        touch();
+        reloader.checkForChanges();
+
+        Files.writeString(queryFile, INITIAL);
+        touch();
+        reloader.checkForChanges();
+
+        assertEquals(1, registry.size());
+        assertNull(registry.get("users.all"));
+    }
+
+    @Test
+    void invalidChangeAppliesWhenValidateOnReloadDisabled() throws IOException {
+        config.getDevtools().setValidateOnReload(false);
+        Files.writeString(queryFile, INVALID);
+        touch();
+        reloader.checkForChanges();
+        // Without validation the broken (but parseable) file is applied as-is.
+        assertNotNull(registry.get("users.broken"));
+        assertNull(registry.get("users.byId"));
+    }
+
+    @Test
+    void missingFileIsIgnored() {
+        config.setQueryFiles(new java.util.LinkedHashMap<>(Map.of(
+                "users", List.of("file:" + queryFile),
+                "ghost", List.of("file:" + tempDir.resolve("missing.yaml")))));
+        reloader.checkForChanges();
+        assertEquals(1, registry.size());
+    }
+}

--- a/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/registry/QueryRegistryTest.java
+++ b/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/registry/QueryRegistryTest.java
@@ -1,0 +1,72 @@
+package lazydevs.readeasy.registry;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class QueryRegistryTest {
+
+    private static final String FILE_A = """
+            queries:
+              byId:
+                raw: '{"nativeSQL": "SELECT * FROM users WHERE id = :id"}'
+              all:
+                raw: '{"nativeSQL": "SELECT * FROM users"}'
+            """;
+
+    private static final String FILE_B = """
+            queries:
+              search:
+                raw: '{"nativeSQL": "SELECT * FROM users WHERE name LIKE :name"}'
+            """;
+
+    private static final String FILE_A_UPDATED = """
+            queries:
+              byId:
+                raw: '{"nativeSQL": "SELECT id, name FROM users WHERE id = :id"}'
+            """;
+
+    @Test
+    void registerAndGet() {
+        QueryRegistry registry = new QueryRegistry(null);
+        assertEquals(2, registry.register("users", "a.yaml", FILE_A));
+        assertNotNull(registry.get("users.byId"));
+        assertNotNull(registry.get("users.all"));
+        assertEquals(2, registry.size());
+    }
+
+    @Test
+    void reloadingOneFileKeepsSiblingFilesOfSameNamespace() {
+        // Regression guard: one namespace fed by two files; re-registering file A
+        // must not remove file B's queries.
+        QueryRegistry registry = new QueryRegistry(null);
+        registry.register("users", "a.yaml", FILE_A);
+        registry.register("users", "b.yaml", FILE_B);
+        assertEquals(3, registry.size());
+
+        registry.register("users", "a.yaml", FILE_A_UPDATED);
+
+        assertNotNull(registry.get("users.byId"), "updated query from a.yaml must exist");
+        assertNull(registry.get("users.all"), "query removed from a.yaml must be gone");
+        assertNotNull(registry.get("users.search"), "b.yaml's query must survive a.yaml's reload");
+        assertEquals(2, registry.size());
+    }
+
+    @Test
+    void reRegisteringSameContentIsIdempotent() {
+        QueryRegistry registry = new QueryRegistry(null);
+        registry.register("users", "a.yaml", FILE_A);
+        registry.register("users", "a.yaml", FILE_A);
+        assertEquals(2, registry.size());
+    }
+
+    @Test
+    void unknownQueryIdReturnsNull() {
+        QueryRegistry registry = new QueryRegistry(null);
+        registry.register("users", "a.yaml", FILE_A);
+        assertNull(registry.get("users.nope"));
+        assertNull(registry.get("other.byId"));
+    }
+}

--- a/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/validation/QueryValidatorTest.java
+++ b/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/validation/QueryValidatorTest.java
@@ -1,0 +1,159 @@
+package lazydevs.readeasy.validation;
+
+import lazydevs.readeasy.validation.QueryValidationException.ValidationError;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class QueryValidatorTest {
+
+    private final QueryValidator validator = new QueryValidator();
+
+    private static final String VALID_FILE = """
+            queries:
+              byId:
+                raw: |
+                  {"nativeSQL": "SELECT * FROM users WHERE id = :id",
+                   "params": [{"name": "id", "type": "STRING", "value": "${params.id}"}]}
+            """;
+
+    @Test
+    void validFilePasses() {
+        List<ValidationError> errors = validator.validateQueryFile(
+                "users", "users.yaml", VALID_FILE, Set.of("default"), true);
+        assertTrue(errors.isEmpty(), () -> "expected no errors but got: " + errors);
+    }
+
+    @Test
+    void unguardedRequestSpecificVariablesAreNotFalsePositives() {
+        // Regression guard: validation must be parse-only. A template referencing a
+        // variable that exists only at request time is valid.
+        String file = """
+                queries:
+                  byCustomer:
+                    raw: |
+                      {"nativeSQL": "SELECT * FROM orders WHERE customer_id = :cid",
+                       "params": [{"name": "cid", "type": "STRING", "value": "${params.customerId}"},
+                                  {"name": "tenant", "type": "STRING", "value": "${request.tenantId}"}]}
+                """;
+        List<ValidationError> errors = validator.validateQueryFile(
+                "orders", "orders.yaml", file, Set.of("default"), true);
+        assertTrue(errors.isEmpty(), () -> "parse-only validation must not fail on runtime variables: " + errors);
+    }
+
+    @Test
+    void missingRawIsFlagged() {
+        String file = """
+                queries:
+                  broken:
+                    readerId: default
+                """;
+        List<ValidationError> errors = validator.validateQueryFile(
+                "ns", "f.yaml", file, Set.of("default"), true);
+        assertEquals(1, errors.size());
+        assertEquals("MISSING_RAW", errors.get(0).getErrorType());
+        assertEquals("ns.broken", errors.get(0).getQueryId());
+    }
+
+    @Test
+    void unknownReaderIdIsFlagged() {
+        String file = """
+                queries:
+                  q1:
+                    readerId: mongo
+                    raw: '{"collectionName": "users"}'
+                """;
+        List<ValidationError> errors = validator.validateQueryFile(
+                "ns", "f.yaml", file, Set.of("default"), true);
+        assertEquals(1, errors.size());
+        assertEquals("INVALID_READER", errors.get(0).getErrorType());
+    }
+
+    @Test
+    void readerCheckSkippedWhenReaderIdsUnknown() {
+        String file = """
+                queries:
+                  q1:
+                    readerId: mongo
+                    raw: '{"collectionName": "users"}'
+                """;
+        assertTrue(validator.validateQueryFile("ns", "f.yaml", file, Set.of(), true).isEmpty());
+        assertTrue(validator.validateQueryFile("ns", "f.yaml", file, null, true).isEmpty());
+    }
+
+    @Test
+    void freeMarkerSyntaxErrorIsFlagged() {
+        String file = """
+                queries:
+                  q1:
+                    raw: |
+                      {"nativeSQL": "SELECT * FROM t <#if params.x?? WHERE x = 1"}
+                """;
+        List<ValidationError> errors = validator.validateQueryFile(
+                "ns", "f.yaml", file, Set.of("default"), true);
+        assertEquals(1, errors.size());
+        assertEquals("TEMPLATE_SYNTAX", errors.get(0).getErrorType());
+    }
+
+    @Test
+    void templateCheckSkippedWhenDisabled() {
+        String file = """
+                queries:
+                  q1:
+                    raw: |
+                      {"nativeSQL": "SELECT 1 <#if broken"}
+                """;
+        assertTrue(validator.validateQueryFile("ns", "f.yaml", file, Set.of("default"), false).isEmpty());
+    }
+
+    @Test
+    void invalidYamlIsFlagged() {
+        List<ValidationError> errors = validator.validateQueryFile(
+                "ns", "f.yaml", "queries: [not, a, map", Set.of("default"), true);
+        assertEquals(1, errors.size());
+        assertEquals("YAML_SYNTAX", errors.get(0).getErrorType());
+    }
+
+    @Test
+    void emptyFileIsFlagged() {
+        List<ValidationError> errors = validator.validateQueryFile(
+                "ns", "f.yaml", "queries: {}", Set.of("default"), true);
+        assertEquals(1, errors.size());
+        assertEquals("MISSING_QUERIES", errors.get(0).getErrorType());
+    }
+
+    @Test
+    void validateAndThrowHonorsFailOnError() {
+        String broken = """
+                queries:
+                  broken:
+                    readerId: default
+                """;
+        assertThrows(QueryValidationException.class, () ->
+                validator.validateAndThrow("ns", "f.yaml", broken, Set.of("default"), true, true));
+        assertDoesNotThrow(() ->
+                validator.validateAndThrow("ns", "f.yaml", broken, Set.of("default"), true, false));
+    }
+
+    @Test
+    void rowTransformerTemplateIsValidated() {
+        String file = """
+                queries:
+                  q1:
+                    raw: '{"nativeSQL": "SELECT 1"}'
+                    rowTransformer:
+                      template: '{"x": "${row.x"}'
+                """;
+        List<ValidationError> errors = validator.validateQueryFile(
+                "ns", "f.yaml", file, Set.of("default"), true);
+        assertEquals(1, errors.size());
+        assertEquals("TEMPLATE_SYNTAX", errors.get(0).getErrorType());
+        assertEquals("ns.q1.rowTransformer", errors.get(0).getQueryId());
+    }
+}

--- a/persistence-utils/src/main/java/lazydevs/mapper/utils/engine/TemplateEngine.java
+++ b/persistence-utils/src/main/java/lazydevs/mapper/utils/engine/TemplateEngine.java
@@ -79,6 +79,23 @@ public class TemplateEngine {
             return stringWriter.toString();
     }
 
+    /**
+     * Parses the template without processing it, so pure syntax errors (unclosed
+     * directives, malformed expressions) surface without any data model. Unlike
+     * {@link #generate}, a template referencing variables that are absent at parse
+     * time is still valid here - only FreeMarker parse errors are reported.
+     *
+     * @throws IllegalArgumentException with FreeMarker's parse message (includes
+     *         line/column) when the template source is not valid FreeMarker
+     */
+    public void validateSyntax(String templateSource) {
+        try {
+            new Template("syntax-validation", templateSource, this.configuration);
+        } catch (IOException e) {
+            throw new IllegalArgumentException(e.getMessage(), e);
+        }
+    }
+
     public void generate(Writer writer, String templateSource, Map<String, Object> datapoints) {
         try {
             Map<String, Object> data = new HashMap<>(datapoints);

--- a/persistence-utils/src/test/java/lazydevs/mapper/utils/engine/TemplateEngineTest.java
+++ b/persistence-utils/src/test/java/lazydevs/mapper/utils/engine/TemplateEngineTest.java
@@ -228,6 +228,21 @@ public class TemplateEngineTest {
         System.out.println(writer.toString());
     }
 
+    @Test
+    public void validateSyntaxAcceptsTemplatesReferencingAbsentVariables(){
+        // Parse-only: variables need not exist at validation time.
+        templateEngine.validateSyntax("SELECT * FROM t WHERE id = ${params.someUnknownVariable}");
+        templateEngine.validateSyntax("<#if params.x??>AND x = :x</#if>");
+    }
+
+    @Test
+    public void validateSyntaxRejectsMalformedTemplates(){
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> templateEngine.validateSyntax("<#if params.x?? AND x = :x"));
+        Assert.expectThrows(IllegalArgumentException.class,
+                () -> templateEngine.validateSyntax("<#list items as i>${i}"));
+    }
+
     @AllArgsConstructor @Getter
     static class Input{
         private String ax, bx, cx, dx;


### PR DESCRIPTION
Rebuilds the developer-experience feature set proposed in #11 on current master.

## What's included

**Startup validation** (new `QueryValidator`)
- Validates query YAML at registration: structure, `raw` presence, `readerId` existence, FreeMarker syntax.
- Template checking is parse-only via a new `TemplateEngine.validateSyntax`: it compiles the template but never renders it, so queries referencing request-time variables (`${params.customerId}`, `${request.userId}`) validate cleanly with zero false positives.
- Config: `readeasy.validation.{enabled, failOnError, validateTemplates}`, all wired. `failOnError` defaults to false so upgrading cannot break an existing app's boot; turn it on in dev for fail-fast.

**Shared `QueryRegistry`**
- Single owner of registered queries, used by both startup registration and hot reload, so registration semantics cannot drift between the two paths.
- Copy-on-write snapshots behind a volatile reference: request threads always read a complete, immutable map (no reader/writer race).
- Registrations are keyed per source file: reloading one file replaces only its own queries, keeping sibling files of the same namespace intact.

**Dev-mode hot reload** (`readeasy.devtools.enabled=true`)
- Polls `file:` resources on a dedicated daemon scheduler instead of Spring scheduling, so enabling it does not switch on `@EnableScheduling` (and dormant `@Scheduled` jobs) in the host application.
- An invalid save is rejected with a readable error and the previous queries stay active.

**Client-safe runtime errors**
- Template render/parse failures throw `QueryTemplateException` extending `RESTException` (HTTP 400). The client message names the query and the missing variable; the template and fully rendered query are written to server logs only, never to the HTTP response.
- The unregistered-readerId case is checked before the parse block so it reports as a reader configuration error, not a parse failure.

**Boot 3 auto-configuration**
- `ReadEasyAutoConfiguration` registered via `META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports` (Boot 3), keeping `spring.factories` for Boot 2 consumers.

**Tests and docs**
- `QueryValidatorTest` (11), `QueryRegistryTest` (4), `DevModeQueryReloaderTest` (6), plus `TemplateEngine` syntax-validation tests; README section documenting the new configuration.

## Why this instead of #11
The in-depth review of #11 found the validation there rendered templates against a hardcoded dummy context with fail-on-boot defaults (breaking existing apps on upgrade), leaked rendered SQL and parameter values to API clients through exception messages, raced request threads against an unsynchronized HashMap during reload, wiped namespace siblings on per-file reload, and was based on a pre-1.0.48 master. This rebuild delivers the same intent with those issues designed out.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable validation for query files, including YAML structure, required templates, reader IDs, and FreeMarker syntax.
  * Added development-mode hot reload for file-based queries, with invalid updates rejected while existing queries remain available.
  * Added automatic query registration and replacement when query files change.
  * Added clear HTTP 400 responses for query template errors while protecting detailed server logs.
* **Documentation**
  * Documented query validation, development tools, hot reload, and template error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->