### PR TITLE
fix(read-easy): skip initialization when read-easy is entirely unconf…

### DIFF
--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/controller/ConfiguredReadController.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/controller/ConfiguredReadController.java
@@ -87,6 +87,13 @@ public class ConfiguredReadController {
     @PostConstruct
     public void init() throws IOException {
         log.info(readInputStreamAsString(applicationContext.getResource(bannerPath).getInputStream()));
+        if (isNothingConfigured()) {
+            // Restoring Boot 3 auto-configuration must not break apps that merely carry
+            // read-easy on the classpath without using it: skip instead of failing boot.
+            // A partial configuration (query files but no readers) still fails fast below.
+            log.warn("read-easy is on the classpath but no readers or query files are configured. Skipping initialization.");
+            return;
+        }
         this.readEasyGeneralReaderMap = getGeneralReader(readEasyGeneralReaderMap, readEasyConfig, applicationContext);
         Set<String> availableReaderIds = this.readEasyGeneralReaderMap.keySet();
         ValidationConfig validation = readEasyConfig.getValidation();
@@ -112,6 +119,13 @@ public class ConfiguredReadController {
         if(null != readEasyConfig.getGlobalContextSupplierInit()) {
             this.globalContextSupplier = ReflectionUtils.getInterfaceReference(readEasyConfig.getGlobalContextSupplierInit(), Supplier.class, (s) -> applicationContext.getBean(s), environment::getProperty);
         }
+    }
+
+    private boolean isNothingConfigured() {
+        return null == readEasyGeneralReaderMap
+                && (null == readEasyConfig.getGeneralReaders() || readEasyConfig.getGeneralReaders().isEmpty())
+                && null == readEasyConfig.getGeneralReaderInit()
+                && readEasyConfig.getQueryFiles().isEmpty();
     }
 
     private Map<String, GeneralReader> getGeneralReader(Map<String, GeneralReader> readEasyGeneralReaderMap, ReadEasyConfig readEasyConfig, ApplicationContext applicationContext){


### PR DESCRIPTION
…igured

Restoring Boot 3 auto-configuration would otherwise abort boot for apps that only carry read-easy on the classpath without configuring readers or query files (on master these apps silently skipped init because spring.factories auto-config is dead on Boot 3). A partial configuration (query files but no readers) still fails fast.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ReadEasy now avoids starting when no readers or query files are configured.
  * A warning is logged when required reading configuration is missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->