### PR TITLE
feat: optional PostgreSQL row-level-security tenant binding via YAML …

### DIFF
--- a/app-building-blocks/read-easy/README.md
+++ b/app-building-blocks/read-easy/README.md
@@ -326,6 +326,58 @@ readeasy:
 A query that fails to render or parse at request time returns HTTP 400 with a short, client-safe message naming the query and the missing variable.
 The full template and rendered query are written to the server log only, never to the HTTP response.
 
+## Multi-Tenancy with PostgreSQL Row-Level Security
+
+Read-Easy can enforce tenant isolation with PostgreSQL row-level security, driven entirely by configuration.
+The tenant id arrives in a request header, is held in `TenantContext` for the request, and is bound to a PostgreSQL session variable on every JDBC connection the reader uses.
+Your RLS policies read that variable, so the database itself filters rows per tenant and no query needs a `WHERE tenant_id = ...` clause.
+
+### 1. Database side (your SQL migrations)
+
+```sql
+ALTER TABLE employee ADD COLUMN tenant_id uuid;
+
+-- The app must connect as a role that does NOT own the table (owners bypass RLS),
+-- or use ALTER TABLE employee FORCE ROW LEVEL SECURITY.
+ALTER TABLE employee ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY employee_tenant_isolation ON employee
+    USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+```
+
+If the variable is not set, `current_setting(..., true)` returns NULL and the policy matches no rows - it fails closed.
+
+### 2. Application side (YAML only)
+
+```yaml
+readeasy:
+  multitenancy:
+    enabled: true
+    headerName: X-Tenant-Id
+    required: true                        # 400 when the header is missing
+    tenantIdPattern: "[0-9a-fA-F-]{36}"   # optional validation
+    urlPatterns:
+      - /read/*
+
+  generalReaders:
+    default:
+      fqcn: lazydevs.persistence.jdbc.general.JdbcGeneralReader
+      constructorArgs:
+        - typeFqcn: javax.sql.DataSource
+          beanName: dataSource
+        - typeFqcn: java.lang.String
+          val: app.tenant_id              # enables RLS binding for this reader
+```
+
+The two-argument `JdbcGeneralReader(dataSource, settingName)` constructor wraps the DataSource in `RlsDataSource`, which runs `SELECT set_config('app.tenant_id', '<tenant>', false)` when a connection is checked out and clears it when the connection is released - including the long-held connection used by `/read/export` streaming.
+A pooled connection therefore never carries one request's tenant into the next.
+Omit the second constructor argument and the reader behaves exactly as before - RLS is opt-in per reader.
+
+By default, acquiring a connection with no tenant in scope throws (fail loud).
+`RlsDataSource` can be constructed with `failWhenTenantMissing=false` for jobs that legitimately run without a tenant; the database policy still fails closed.
+
+`JdbcGeneralUpdater` has the same two-argument constructor for RLS-enforced writes.
+
 ## Working with Different Databases
 
 ### JDBC (SQL Databases)

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/beans/ReadEasyAutoConfiguration.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/beans/ReadEasyAutoConfiguration.java
@@ -1,16 +1,20 @@
 package lazydevs.readeasy.beans;
 
 import lazydevs.readeasy.config.ReadEasyConfig;
+import lazydevs.readeasy.config.ReadEasyConfig.MultitenancyConfig;
 import lazydevs.readeasy.controller.ConfiguredReadController;
 import lazydevs.readeasy.devtools.DevModeQueryReloader;
 import lazydevs.readeasy.registry.QueryRegistry;
+import lazydevs.readeasy.web.TenantFilter;
 import lazydevs.services.basic.validation.ParamValidator;
 import lazydevs.springhelpers.dynabeans.DynaBeansAutoConfiguration;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.web.servlet.FilterRegistrationBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.Ordered;
 import org.springframework.core.io.ResourceLoader;
 
 /**
@@ -46,5 +50,16 @@ public class ReadEasyAutoConfiguration {
                                                     ResourceLoader resourceLoader,
                                                     QueryRegistry queryRegistry) {
         return new DevModeQueryReloader(readEasyConfig, resourceLoader, queryRegistry);
+    }
+
+    @Bean
+    @ConditionalOnProperty(name = "readeasy.multitenancy.enabled", havingValue = "true")
+    public FilterRegistrationBean<TenantFilter> readEasyTenantFilter(ReadEasyConfig readEasyConfig) {
+        MultitenancyConfig multitenancy = readEasyConfig.getMultitenancy();
+        FilterRegistrationBean<TenantFilter> registration =
+                new FilterRegistrationBean<>(new TenantFilter(multitenancy));
+        registration.setUrlPatterns(multitenancy.getUrlPatterns());
+        registration.setOrder(Ordered.HIGHEST_PRECEDENCE + 100);
+        return registration;
     }
 }

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/config/ReadEasyConfig.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/config/ReadEasyConfig.java
@@ -176,6 +176,42 @@ public class ReadEasyConfig{
     private DevtoolsConfig devtools = new DevtoolsConfig();
 
     /**
+     * Multi-tenancy settings: extracts the tenant id from a request header into
+     * {@code TenantContext}, where RLS-aware readers (e.g.
+     * {@code JdbcGeneralReader(dataSource, "app.tenant_id")}) pick it up.
+     */
+    private MultitenancyConfig multitenancy = new MultitenancyConfig();
+
+    /**
+     * Configuration for header-based tenant resolution.
+     *
+     * <p>Example:</p>
+     * <pre>{@code
+     * readeasy:
+     *   multitenancy:
+     *     enabled: true             # default: false
+     *     headerName: X-Tenant-Id
+     *     required: true            # 400 when the header is absent (default: true)
+     *     tenantIdPattern: "[0-9a-fA-F-]{36}"  # optional regex validation
+     *     urlPatterns:              # servlet paths the filter applies to
+     *       - /read/*
+     * }</pre>
+     */
+    @Getter @Setter @ToString
+    public static class MultitenancyConfig {
+        /** Enable the tenant header filter. */
+        private boolean enabled = false;
+        /** Header carrying the tenant id. */
+        private String headerName = "X-Tenant-Id";
+        /** Reject requests without the header with HTTP 400; when false, requests proceed with no tenant in scope. */
+        private boolean required = true;
+        /** Optional regex the header value must match (anchored full match); invalid values get HTTP 400. */
+        private String tenantIdPattern;
+        /** Servlet url patterns the filter is registered for. */
+        private List<String> urlPatterns = new ArrayList<>(List.of("/read/*"));
+    }
+
+    /**
      * Configuration for startup-time query validation.
      *
      * <p>Template validation is a FreeMarker parse-only check: it catches syntax

--- a/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/web/TenantFilter.java
+++ b/app-building-blocks/read-easy/src/main/java/lazydevs/readeasy/web/TenantFilter.java
@@ -1,0 +1,64 @@
+package lazydevs.readeasy.web;
+
+import lazydevs.persistence.connection.multitenant.TenantContext;
+import lazydevs.readeasy.config.ReadEasyConfig.MultitenancyConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.regex.Pattern;
+
+/**
+ * Extracts the tenant id from a request header into {@link TenantContext} for
+ * the duration of the request, and always clears it afterwards so pooled
+ * threads never carry one request's tenant into the next.
+ *
+ * <p>Downstream, RLS-aware components read the tenant from TenantContext -
+ * e.g. {@code JdbcGeneralReader(dataSource, "app.tenant_id")} binds it to the
+ * PostgreSQL session variable that row-level-security policies evaluate.</p>
+ *
+ * @author Abhijeet Rai
+ */
+@Slf4j
+public class TenantFilter extends OncePerRequestFilter {
+
+    private final MultitenancyConfig config;
+    private final Pattern tenantIdPattern;
+
+    public TenantFilter(MultitenancyConfig config) {
+        this.config = config;
+        this.tenantIdPattern = null == config.getTenantIdPattern()
+                ? null : Pattern.compile(config.getTenantIdPattern());
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String tenantId = request.getHeader(config.getHeaderName());
+        if (null == tenantId || tenantId.trim().isEmpty()) {
+            if (config.isRequired()) {
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                        "Missing required header: " + config.getHeaderName());
+                return;
+            }
+            filterChain.doFilter(request, response);
+            return;
+        }
+        tenantId = tenantId.trim();
+        if (null != tenantIdPattern && !tenantIdPattern.matcher(tenantId).matches()) {
+            response.sendError(HttpServletResponse.SC_BAD_REQUEST,
+                    "Invalid value for header: " + config.getHeaderName());
+            return;
+        }
+        TenantContext.setTenantId(tenantId);
+        try {
+            filterChain.doFilter(request, response);
+        } finally {
+            TenantContext.reset();
+        }
+    }
+}

--- a/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/web/TenantFilterTest.java
+++ b/app-building-blocks/read-easy/src/test/java/lazydevs/readeasy/web/TenantFilterTest.java
@@ -1,0 +1,138 @@
+package lazydevs.readeasy.web;
+
+import lazydevs.persistence.connection.multitenant.TenantContext;
+import lazydevs.readeasy.config.ReadEasyConfig.MultitenancyConfig;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class TenantFilterTest {
+
+    private final List<String> errors = new ArrayList<>();
+    private final AtomicReference<String> tenantSeenByChain = new AtomicReference<>();
+
+    private HttpServletRequest request(String headerName, String headerValue) {
+        return (HttpServletRequest) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[]{HttpServletRequest.class}, (proxy, method, args) -> {
+                    if ("getHeader".equals(method.getName())) {
+                        return headerName.equalsIgnoreCase((String) args[0]) ? headerValue : null;
+                    }
+                    throw new UnsupportedOperationException("HttpServletRequest." + method.getName());
+                });
+    }
+
+    private HttpServletResponse response() {
+        return (HttpServletResponse) Proxy.newProxyInstance(getClass().getClassLoader(),
+                new Class<?>[]{HttpServletResponse.class}, (proxy, method, args) -> {
+                    if ("sendError".equals(method.getName())) {
+                        errors.add(args[0] + ":" + args[1]);
+                        return null;
+                    }
+                    throw new UnsupportedOperationException("HttpServletResponse." + method.getName());
+                });
+    }
+
+    private FilterChain chain() {
+        return (request, response) -> tenantSeenByChain.set(TenantContext.getTenantId());
+    }
+
+    private MultitenancyConfig config() {
+        MultitenancyConfig config = new MultitenancyConfig();
+        config.setEnabled(true);
+        return config;
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.reset();
+    }
+
+    @Test
+    void setsTenantForChainAndClearsAfterwards() throws Exception {
+        new TenantFilter(config()).doFilterInternal(
+                request("X-Tenant-Id", "tenant-42"), response(), chain());
+        assertEquals("tenant-42", tenantSeenByChain.get());
+        assertNull(TenantContext.getTenantId(), "tenant must be cleared after the request");
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void clearsTenantEvenWhenChainThrows() {
+        try {
+            new TenantFilter(config()).doFilterInternal(
+                    request("X-Tenant-Id", "t1"), response(),
+                    (request, response) -> { throw new RuntimeException("boom"); });
+        } catch (Exception expected) {
+            // ignore
+        }
+        assertNull(TenantContext.getTenantId());
+    }
+
+    @Test
+    void missingHeaderIsRejectedWhenRequired() throws Exception {
+        new TenantFilter(config()).doFilterInternal(
+                request("X-Tenant-Id", null), response(), chain());
+        assertEquals(1, errors.size());
+        assertTrue(errors.get(0).startsWith("400:"));
+        assertNull(tenantSeenByChain.get(), "chain must not run");
+    }
+
+    @Test
+    void missingHeaderPassesThroughWhenOptional() throws Exception {
+        MultitenancyConfig config = config();
+        config.setRequired(false);
+        AtomicReference<Boolean> chainRan = new AtomicReference<>(false);
+        new TenantFilter(config).doFilterInternal(
+                request("X-Tenant-Id", null), response(),
+                (request, response) -> chainRan.set(true));
+        assertTrue(chainRan.get());
+        assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    void customHeaderNameIsHonored() throws Exception {
+        MultitenancyConfig config = config();
+        config.setHeaderName("X-Org-Id");
+        new TenantFilter(config).doFilterInternal(
+                request("X-Org-Id", "org-7"), response(), chain());
+        assertEquals("org-7", tenantSeenByChain.get());
+    }
+
+    @Test
+    void patternMismatchIsRejected() throws Exception {
+        MultitenancyConfig config = config();
+        config.setTenantIdPattern("[0-9a-f-]{36}");
+        new TenantFilter(config).doFilterInternal(
+                request("X-Tenant-Id", "not-a-uuid'; drop table employee"), response(), chain());
+        assertEquals(1, errors.size());
+        assertNull(tenantSeenByChain.get());
+    }
+
+    @Test
+    void patternMatchPasses() throws Exception {
+        MultitenancyConfig config = config();
+        config.setTenantIdPattern("[0-9a-f-]{36}");
+        String uuid = "0b862a1f-3d5e-4c6a-9b21-8d3f5a7c9e01";
+        new TenantFilter(config).doFilterInternal(
+                request("X-Tenant-Id", uuid), response(), chain());
+        assertEquals(uuid, tenantSeenByChain.get());
+    }
+
+    @Test
+    void headerValueIsTrimmed() throws Exception {
+        new TenantFilter(config()).doFilterInternal(
+                request("X-Tenant-Id", "  t1  "), response(), chain());
+        assertEquals("t1", tenantSeenByChain.get());
+    }
+}

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralReader.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralReader.java
@@ -3,6 +3,7 @@
 import lazydevs.mapper.db.jdbc.ResultSetMapper;
 import lazydevs.mapper.utils.BatchIterator;
 import lazydevs.persistence.connection.ConnectionProvider;
+import lazydevs.persistence.jdbc.rls.RlsDataSource;
 import lazydevs.persistence.reader.GeneralReader;
 import lazydevs.persistence.reader.Page;
 import lombok.extern.slf4j.Slf4j;
@@ -26,6 +27,17 @@ public class JdbcGeneralReader implements GeneralReader<JdbcOperation, Object> {
 
     public JdbcGeneralReader(DataSource dataSource){
         this.connectionProvider = () ->  dataSource;
+    }
+
+    /**
+     * Reads through an {@link RlsDataSource} so every query runs with the current
+     * tenant bound to the given PostgreSQL session variable, letting row-level
+     * security policies (e.g. {@code USING (tenant_id = current_setting('app.tenant_id', true)::uuid)})
+     * filter rows per tenant. Wire it from YAML/InitDTO config as
+     * (beanName: dataSource, val: app.tenant_id).
+     */
+    public JdbcGeneralReader(DataSource dataSource, String rlsSettingName){
+        this(new RlsDataSource(dataSource, rlsSettingName));
     }
 
     @Override

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralUpdater.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralUpdater.java
@@ -5,6 +5,7 @@ import lazydevs.mapper.db.jdbc.JdbcRepository;
 import lazydevs.mapper.db.jdbc.simple.EntityAwarePreparedStatementSetter;
 import lazydevs.mapper.utils.engine.TemplateEngine;
 import lazydevs.persistence.connection.ConnectionProvider;
+import lazydevs.persistence.jdbc.rls.RlsDataSource;
 import lazydevs.persistence.writer.general.GeneralUpdater;
 import lombok.extern.slf4j.Slf4j;
 
@@ -31,6 +32,15 @@ public class JdbcGeneralUpdater implements GeneralUpdater<JdbcOperation, JdbcOpe
 
     public JdbcGeneralUpdater(DataSource dataSource){
         this(() ->  dataSource);
+    }
+
+    /**
+     * Writes through an {@link RlsDataSource} so inserts/updates/deletes run with
+     * the current tenant bound to the given PostgreSQL session variable, letting
+     * row-level security policies enforce tenant isolation on writes too.
+     */
+    public JdbcGeneralUpdater(DataSource dataSource, String rlsSettingName){
+        this(new RlsDataSource(dataSource, rlsSettingName));
     }
 
     @Override

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsDataSource.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsDataSource.java
@@ -1,0 +1,138 @@
+package lazydevs.persistence.jdbc.rls;
+
+import lombok.extern.slf4j.Slf4j;
+
+import javax.sql.DataSource;
+import java.io.PrintWriter;
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.SQLFeatureNotSupportedException;
+import java.util.logging.Logger;
+
+/**
+ * A {@link DataSource} decorator that binds the current tenant to every
+ * connection it hands out, enabling PostgreSQL row-level-security policies
+ * keyed on a session variable (e.g. {@code app.tenant_id}).
+ *
+ * <p>On {@code getConnection()} it runs
+ * {@code SELECT set_config('&lt;settingName&gt;', '&lt;tenant&gt;', false)} and returns the
+ * connection wrapped in a {@link TenantBoundConnection}, whose {@code close()}
+ * clears the variable before the connection returns to the pool. Because every
+ * JDBC path in this library (including batch iterators that hold the connection
+ * open across a streamed export) acquires and closes connections through the
+ * DataSource, decorating at this seam covers all of them.</p>
+ *
+ * <p>When no tenant is in scope, the default is to throw (fail loud); with
+ * {@code failWhenTenantMissing=false} the raw connection is returned unbound and
+ * the database policy itself fails closed (an unset variable matches no rows).</p>
+ *
+ * <p>The DB side (policies, roles) is owned by your SQL migrations, e.g.:</p>
+ * <pre>{@code
+ * ALTER TABLE employee ENABLE ROW LEVEL SECURITY;
+ * CREATE POLICY employee_tenant_isolation ON employee
+ *     USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+ * }</pre>
+ *
+ * @author Abhijeet Rai
+ */
+@Slf4j
+public class RlsDataSource implements DataSource {
+
+    private final DataSource delegate;
+    private final RlsSettings settings;
+
+    public RlsDataSource(DataSource delegate, RlsSettings settings) {
+        if (null == delegate) {
+            throw new IllegalArgumentException("delegate DataSource is required");
+        }
+        this.delegate = delegate;
+        this.settings = null == settings ? RlsSettings.defaults() : settings;
+    }
+
+    public RlsDataSource(DataSource delegate) {
+        this(delegate, RlsSettings.defaults());
+    }
+
+    /** Convenience constructor for config-driven wiring (e.g. read-easy InitDTO YAML). */
+    public RlsDataSource(DataSource delegate, String settingName) {
+        this(delegate, new RlsSettings(settingName));
+    }
+
+    @Override
+    public Connection getConnection() throws SQLException {
+        return bindTenant(delegate.getConnection());
+    }
+
+    @Override
+    public Connection getConnection(String username, String password) throws SQLException {
+        return bindTenant(delegate.getConnection(username, password));
+    }
+
+    private Connection bindTenant(Connection connection) throws SQLException {
+        String tenantId = settings.getTenantSupplier().get();
+        if (null == tenantId || tenantId.isEmpty()) {
+            if (settings.isFailWhenTenantMissing()) {
+                closeQuietly(connection);
+                throw new IllegalStateException("No tenant in scope while acquiring an RLS-bound connection ("
+                        + settings.getSettingName() + "). Set TenantContext (or configure failWhenTenantMissing=false).");
+            }
+            log.debug("No tenant in scope; returning connection without setting {}", settings.getSettingName());
+            return connection;
+        }
+        try {
+            TenantBoundConnection.setConfig(connection, settings.getSettingName(), tenantId);
+        } catch (SQLException e) {
+            closeQuietly(connection);
+            throw e;
+        }
+        return TenantBoundConnection.wrap(connection, settings.getSettingName());
+    }
+
+    private void closeQuietly(Connection connection) {
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            log.warn("Failed to close connection after tenant binding failure", e);
+        }
+    }
+
+    //=================== plain delegation ===================
+
+    @Override
+    public PrintWriter getLogWriter() throws SQLException {
+        return delegate.getLogWriter();
+    }
+
+    @Override
+    public void setLogWriter(PrintWriter out) throws SQLException {
+        delegate.setLogWriter(out);
+    }
+
+    @Override
+    public void setLoginTimeout(int seconds) throws SQLException {
+        delegate.setLoginTimeout(seconds);
+    }
+
+    @Override
+    public int getLoginTimeout() throws SQLException {
+        return delegate.getLoginTimeout();
+    }
+
+    @Override
+    public Logger getParentLogger() throws SQLFeatureNotSupportedException {
+        return delegate.getParentLogger();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> iface) throws SQLException {
+        if (iface.isInstance(this)) {
+            return iface.cast(this);
+        }
+        return delegate.unwrap(iface);
+    }
+
+    @Override
+    public boolean isWrapperFor(Class<?> iface) throws SQLException {
+        return iface.isInstance(this) || delegate.isWrapperFor(iface);
+    }
+}

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsSettings.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsSettings.java
@@ -1,0 +1,61 @@
+package lazydevs.persistence.jdbc.rls;
+
+import lazydevs.persistence.connection.multitenant.TenantContext;
+import lombok.Getter;
+import lombok.ToString;
+
+import java.util.function.Supplier;
+import java.util.regex.Pattern;
+
+/**
+ * Settings for row-level-security tenant binding. Immutable.
+ *
+ * <p>The setting name must be a custom PostgreSQL GUC of the form
+ * {@code prefix.name} (e.g. {@code app.tenant_id}) matching what the table's
+ * RLS policy reads via {@code current_setting('app.tenant_id', true)}.</p>
+ *
+ * @author Abhijeet Rai
+ */
+@Getter @ToString
+public class RlsSettings {
+
+    public static final String DEFAULT_SETTING_NAME = "app.tenant_id";
+
+    /** Custom GUCs require a dot-separated two-part name. */
+    private static final Pattern SETTING_NAME_PATTERN =
+            Pattern.compile("[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*");
+
+    /** The PostgreSQL session variable the RLS policy reads. */
+    private final String settingName;
+
+    /**
+     * When true (the default), acquiring a connection with no tenant in scope
+     * throws instead of returning an unbound connection. The database policy
+     * fails closed either way; this makes the mistake loud instead of silent.
+     */
+    private final boolean failWhenTenantMissing;
+
+    /** Where the current tenant comes from. Defaults to {@link TenantContext#getTenantId()}. */
+    @ToString.Exclude
+    private final Supplier<String> tenantSupplier;
+
+    public RlsSettings(String settingName, boolean failWhenTenantMissing, Supplier<String> tenantSupplier) {
+        if (null == settingName || !SETTING_NAME_PATTERN.matcher(settingName).matches()) {
+            throw new IllegalArgumentException("RLS settingName must be a two-part custom GUC name like 'app.tenant_id', but was: " + settingName);
+        }
+        if (null == tenantSupplier) {
+            throw new IllegalArgumentException("tenantSupplier is required");
+        }
+        this.settingName = settingName;
+        this.failWhenTenantMissing = failWhenTenantMissing;
+        this.tenantSupplier = tenantSupplier;
+    }
+
+    public RlsSettings(String settingName) {
+        this(settingName, true, TenantContext::getTenantId);
+    }
+
+    public static RlsSettings defaults() {
+        return new RlsSettings(DEFAULT_SETTING_NAME);
+    }
+}

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/TenantBoundConnection.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/TenantBoundConnection.java
@@ -1,0 +1,79 @@
+package lazydevs.persistence.jdbc.rls;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+/**
+ * A {@link Connection} proxy whose {@code close()} clears the tenant session
+ * variable before returning the connection to the pool, so a pooled connection
+ * can never carry one request's tenant into the next request.
+ *
+ * <p>If the reset itself fails, the underlying physical connection is closed
+ * hard so a dirty session cannot re-enter the pool.</p>
+ *
+ * @author Abhijeet Rai
+ */
+public final class TenantBoundConnection implements InvocationHandler {
+
+    private final Connection delegate;
+    private final String settingName;
+
+    private TenantBoundConnection(Connection delegate, String settingName) {
+        this.delegate = delegate;
+        this.settingName = settingName;
+    }
+
+    public static Connection wrap(Connection delegate, String settingName) {
+        return (Connection) Proxy.newProxyInstance(
+                TenantBoundConnection.class.getClassLoader(),
+                new Class<?>[]{Connection.class},
+                new TenantBoundConnection(delegate, settingName));
+    }
+
+    /** Executes {@code SELECT set_config(name, value, false)} on the given connection. */
+    static void setConfig(Connection connection, String settingName, String value) throws SQLException {
+        try (PreparedStatement ps = connection.prepareStatement("SELECT set_config(?, ?, false)")) {
+            ps.setString(1, settingName);
+            ps.setString(2, value);
+            ps.execute();
+        }
+    }
+
+    @Override
+    public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+        if ("close".equals(method.getName()) && (null == args || args.length == 0)) {
+            close();
+            return null;
+        }
+        try {
+            return method.invoke(delegate, args);
+        } catch (InvocationTargetException e) {
+            throw e.getTargetException();
+        }
+    }
+
+    private void close() throws SQLException {
+        if (delegate.isClosed()) {
+            return;
+        }
+        try {
+            // Empty value fails closed: a policy casting current_setting(...) to uuid
+            // errors loudly, and an equality check matches no tenant.
+            setConfig(delegate, settingName, "");
+        } catch (SQLException resetFailure) {
+            try {
+                delegate.close();
+            } catch (SQLException closeFailure) {
+                resetFailure.addSuppressed(closeFailure);
+            }
+            throw new SQLException("Failed to reset RLS setting '" + settingName
+                    + "' on connection close; the physical connection was closed to keep the pool clean.", resetFailure);
+        }
+        delegate.close();
+    }
+}

--- a/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsDataSourceTest.java
+++ b/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsDataSourceTest.java
@@ -1,0 +1,165 @@
+package lazydevs.persistence.jdbc.rls;
+
+import lazydevs.persistence.connection.multitenant.TenantContext;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.Proxy;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class RlsDataSourceTest {
+
+    /** Records set_config invocations as "name=value" and connection close events. */
+    static class FakeDb {
+        final List<String> events = new ArrayList<>();
+        boolean failOnSetConfig = false;
+        boolean closed = false;
+        String pendingName;
+        String pendingValue;
+
+        Connection connection() {
+            InvocationHandler psHandler = null; // assigned per prepareStatement
+            return (Connection) Proxy.newProxyInstance(getClass().getClassLoader(),
+                    new Class<?>[]{Connection.class}, (proxy, method, args) -> {
+                        switch (method.getName()) {
+                            case "prepareStatement":
+                                String sql = (String) args[0];
+                                assertTrue(sql.contains("set_config"), "unexpected SQL: " + sql);
+                                return preparedStatement();
+                            case "isClosed":
+                                return closed;
+                            case "close":
+                                closed = true;
+                                events.add("connection-closed");
+                                return null;
+                            case "toString":
+                                return "FakeConnection";
+                            default:
+                                throw new UnsupportedOperationException("Connection." + method.getName());
+                        }
+                    });
+        }
+
+        private PreparedStatement preparedStatement() {
+            return (PreparedStatement) Proxy.newProxyInstance(getClass().getClassLoader(),
+                    new Class<?>[]{PreparedStatement.class}, (proxy, method, args) -> {
+                        switch (method.getName()) {
+                            case "setString":
+                                if ((Integer) args[0] == 1) pendingName = (String) args[1];
+                                else pendingValue = (String) args[1];
+                                return null;
+                            case "execute":
+                                if (failOnSetConfig) throw new SQLException("simulated set_config failure");
+                                events.add(pendingName + "=" + pendingValue);
+                                return true;
+                            case "close":
+                                return null;
+                            default:
+                                throw new UnsupportedOperationException("PreparedStatement." + method.getName());
+                        }
+                    });
+        }
+
+        DataSource dataSource() {
+            return (DataSource) Proxy.newProxyInstance(getClass().getClassLoader(),
+                    new Class<?>[]{DataSource.class}, (proxy, method, args) -> {
+                        if ("getConnection".equals(method.getName())) return connection();
+                        throw new UnsupportedOperationException("DataSource." + method.getName());
+                    });
+        }
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.reset();
+    }
+
+    @Test
+    void bindsTenantOnCheckoutAndResetsOnClose() throws SQLException {
+        FakeDb db = new FakeDb();
+        TenantContext.setTenantId("tenant-1");
+        RlsDataSource rls = new RlsDataSource(db.dataSource());
+
+        Connection connection = rls.getConnection();
+        assertEquals(List.of("app.tenant_id=tenant-1"), db.events);
+
+        connection.close();
+        assertEquals(List.of("app.tenant_id=tenant-1", "app.tenant_id=", "connection-closed"), db.events);
+    }
+
+    @Test
+    void doubleCloseIsIdempotent() throws SQLException {
+        FakeDb db = new FakeDb();
+        TenantContext.setTenantId("tenant-1");
+        Connection connection = new RlsDataSource(db.dataSource()).getConnection();
+        connection.close();
+        connection.close();
+        assertEquals(List.of("app.tenant_id=tenant-1", "app.tenant_id=", "connection-closed"), db.events);
+    }
+
+    @Test
+    void missingTenantFailsLoudAndReleasesConnection() {
+        FakeDb db = new FakeDb();
+        RlsDataSource rls = new RlsDataSource(db.dataSource());
+        assertThrows(IllegalStateException.class, rls::getConnection);
+        assertEquals(List.of("connection-closed"), db.events);
+    }
+
+    @Test
+    void missingTenantPassesThroughWhenConfiguredLenient() throws SQLException {
+        FakeDb db = new FakeDb();
+        RlsDataSource rls = new RlsDataSource(db.dataSource(),
+                new RlsSettings("app.tenant_id", false, TenantContext::getTenantId));
+        Connection connection = rls.getConnection();
+        assertTrue(db.events.isEmpty(), "no set_config expected without a tenant");
+        connection.close();
+        assertEquals(List.of("connection-closed"), db.events);
+    }
+
+    @Test
+    void setConfigFailureOnCheckoutReleasesConnection() {
+        FakeDb db = new FakeDb();
+        db.failOnSetConfig = true;
+        TenantContext.setTenantId("tenant-1");
+        RlsDataSource rls = new RlsDataSource(db.dataSource());
+        assertThrows(SQLException.class, rls::getConnection);
+        assertEquals(List.of("connection-closed"), db.events);
+    }
+
+    @Test
+    void resetFailureOnCloseHardClosesPhysicalConnection() throws SQLException {
+        FakeDb db = new FakeDb();
+        TenantContext.setTenantId("tenant-1");
+        Connection connection = new RlsDataSource(db.dataSource()).getConnection();
+        db.failOnSetConfig = true;
+        assertThrows(SQLException.class, connection::close);
+        assertEquals(List.of("app.tenant_id=tenant-1", "connection-closed"), db.events);
+    }
+
+    @Test
+    void customSettingNameIsUsed() throws SQLException {
+        FakeDb db = new FakeDb();
+        TenantContext.setTenantId("t9");
+        Connection connection = new RlsDataSource(db.dataSource(), "myapp.org_id").getConnection();
+        connection.close();
+        assertEquals(List.of("myapp.org_id=t9", "myapp.org_id=", "connection-closed"), db.events);
+    }
+
+    @Test
+    void invalidSettingNamesAreRejected() {
+        FakeDb db = new FakeDb();
+        assertThrows(IllegalArgumentException.class, () -> new RlsDataSource(db.dataSource(), "tenant_id"));
+        assertThrows(IllegalArgumentException.class, () -> new RlsDataSource(db.dataSource(), "app.tenant id"));
+        assertThrows(IllegalArgumentException.class, () -> new RlsDataSource(db.dataSource(), "app.x; drop table t"));
+    }
+}

--- a/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsEndToEndTest.java
+++ b/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsEndToEndTest.java
@@ -1,0 +1,99 @@
+package lazydevs.persistence.jdbc.rls;
+
+import lazydevs.persistence.connection.multitenant.TenantContext;
+import lazydevs.persistence.jdbc.general.JdbcGeneralReader;
+import lazydevs.persistence.jdbc.general.JdbcOperation;
+import lazydevs.mapper.utils.BatchIterator;
+import org.h2.jdbcx.JdbcDataSource;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.sql.Connection;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Proves the full wiring through {@link JdbcGeneralReader}: the tenant GUC is
+ * set before the query runs and cleared when the connection is released - on
+ * the plain query path and on the connection-escaping batch path used by
+ * exports. H2 stands in for PostgreSQL via a {@code SET_CONFIG} alias that
+ * records invocations; the actual row filtering is PostgreSQL's job and is
+ * covered by the policy, not this test.
+ */
+public class RlsEndToEndTest {
+
+    /** Recorded set_config calls, as "name=value". H2 alias writes here. */
+    static final List<String> SET_CONFIG_CALLS = new ArrayList<>();
+
+    @SuppressWarnings("unused") // referenced by the H2 CREATE ALIAS below
+    public static String setConfig(String name, String value, boolean isLocal) {
+        SET_CONFIG_CALLS.add(name + "=" + value);
+        return value;
+    }
+
+    private static JdbcDataSource h2;
+
+    @BeforeAll
+    static void setUpDatabase() throws Exception {
+        h2 = new JdbcDataSource();
+        h2.setURL("jdbc:h2:mem:rlstest;DB_CLOSE_DELAY=-1");
+        try (Connection c = h2.getConnection(); Statement s = c.createStatement()) {
+            s.execute("create alias if not exists set_config for \""
+                    + RlsEndToEndTest.class.getName() + ".setConfig\"");
+            s.execute("create table employee (id int primary key, name varchar(50), tenant_id varchar(36))");
+            s.execute("insert into employee values (1, 'A', 't1'), (2, 'B', 't2')");
+        }
+    }
+
+    @BeforeEach
+    void reset() {
+        SET_CONFIG_CALLS.clear();
+        TenantContext.setTenantId("t1");
+    }
+
+    @AfterEach
+    void cleanup() {
+        TenantContext.reset();
+    }
+
+    @Test
+    void findAllSetsTenantBeforeQueryAndClearsAfter() {
+        JdbcGeneralReader reader = new JdbcGeneralReader(h2, "app.tenant_id");
+        List<Map<String, Object>> rows = reader.findAll(
+                JdbcOperation.nativeSql("select * from employee order by id"), Map.of());
+        assertEquals(2, rows.size());
+        assertEquals(List.of("app.tenant_id=t1", "app.tenant_id="), SET_CONFIG_CALLS);
+    }
+
+    @Test
+    void batchIterationClearsTenantWhenIteratorCloses() throws Exception {
+        JdbcGeneralReader reader = new JdbcGeneralReader(h2, "app.tenant_id");
+        try (BatchIterator<Map<String, Object>> it = reader.findAllInBatch(1,
+                JdbcOperation.nativeSql("select * from employee order by id"), Map.of())) {
+            int count = 0;
+            while (it.hasNext()) {
+                count += it.next().size();
+            }
+            assertEquals(2, count);
+            // Connection is still held by the iterator: tenant set, not yet cleared.
+            assertEquals(List.of("app.tenant_id=t1"), SET_CONFIG_CALLS);
+        }
+        assertEquals(List.of("app.tenant_id=t1", "app.tenant_id="), SET_CONFIG_CALLS);
+    }
+
+    @Test
+    void countAndFindOneEachGetTheirOwnBoundConnection() {
+        JdbcGeneralReader reader = new JdbcGeneralReader(h2, "app.tenant_id");
+        reader.count(JdbcOperation.nativeSql("select * from employee"), Map.of());
+        reader.findOne(JdbcOperation.nativeSql("select * from employee where id = 1"), Map.of());
+        assertEquals(List.of(
+                "app.tenant_id=t1", "app.tenant_id=",
+                "app.tenant_id=t1", "app.tenant_id="), SET_CONFIG_CALLS);
+    }
+}


### PR DESCRIPTION
…config

simple-jdbc-persistence (new lazydevs.persistence.jdbc.rls package):
- RlsDataSource: DataSource decorator that runs set_config('<settingName>', '<tenant>', false) when a connection is checked out and returns it wrapped in TenantBoundConnection, whose close() clears the variable before the connection re-enters the pool. Covers every JDBC path including the connection-escaping batch iterator used by streamed exports. If the reset fails, the physical connection is closed hard so a dirty session never returns to the pool.
- RlsSettings: settingName (validated two-part GUC name), fail-loud vs lenient behavior when no tenant is in scope (DB policy fails closed either way), pluggable tenant supplier defaulting to TenantContext.
- JdbcGeneralReader/JdbcGeneralUpdater gain a (DataSource, settingName) constructor so RLS is enabled per reader straight from InitDTO YAML, with no extra Spring DataSource bean to break by-type injection.

read-easy:
- readeasy.multitenancy config block: headerName (X-Tenant-Id), required, optional tenantIdPattern, urlPatterns (default /read/*).
- TenantFilter populates TenantContext from the header for the request and always clears it; registered via FilterRegistrationBean when readeasy.multitenancy.enabled=true.
- README: full walkthrough incl. the manual SQL (policy on current_setting('app.tenant_id', true)) and the YAML reader wiring.

Tests: RlsDataSourceTest (checkout/reset/failure semantics via JDBC proxies), RlsEndToEndTest (H2 set_config alias proving bind-before-query and clear-on-release through JdbcGeneralReader, including the batch path), TenantFilterTest.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional multi-tenancy support using tenant IDs from configurable request headers.
  * Added tenant validation, required-header handling, and request-scoped tenant isolation.
  * Added PostgreSQL row-level security support for tenant-filtered reads and writes.
  * Tenant context is automatically cleared between requests and database connections.

* **Documentation**
  * Added configuration and setup guidance for multi-tenancy and PostgreSQL row-level security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->