### PR TITLE
fix(rls): bind a stand-in when no tenant is in scope, instead of leaving the connection unbound

### DIFF
--- a/app-building-blocks/read-easy/README.md
+++ b/app-building-blocks/read-easy/README.md
@@ -342,12 +342,60 @@ ALTER TABLE employee ADD COLUMN tenant_id uuid;
 ALTER TABLE employee ENABLE ROW LEVEL SECURITY;
 
 CREATE POLICY employee_tenant_isolation ON employee
-    USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+    USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
 ```
 
-If the variable is not set, `current_setting(..., true)` returns NULL and the policy matches no rows - it fails closed.
+**Write the `nullif(..., '')` in, even if you think you do not need it.** A custom
+PostgreSQL GUC has three possible states, not two, and the third one bites:
 
-### 2. Application side (YAML only)
+| session state | `current_setting('app.tenant_id', true)` |
+|---|---|
+| never written in this session | `NULL` |
+| bound to a tenant | the tenant id |
+| **released back to the pool** | `''` — *not* `NULL` |
+
+There is no way back to the first state once the variable has been written:
+`set_config(name, NULL, false)`, `RESET name` and even `DISCARD ALL` all leave the
+empty string. So on a pooled connection the empty string is the normal cleared
+state, and `''::uuid` raises `invalid input syntax for type uuid: ""` rather than
+matching nothing. `nullif(current_setting(...), '')::uuid` folds it back to NULL,
+which is correct in all three states. A `text` tenant column needs no cast and is
+safe either way.
+
+### 2. Shared rows: `tenant_id IS NULL` visible to every tenant
+
+Plenty of schemas are not "every row belongs to exactly one tenant". A row with
+no owner — a platform default, a shared catalogue, a pool every customer can
+draw from — is usually modelled as a nullable `tenant_id`, readable by all and
+writable by none of them:
+
+```sql
+CREATE POLICY employee_read ON employee FOR SELECT
+    USING (tenant_id IS NULL                                                -- shared
+           OR tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+
+CREATE POLICY employee_write ON employee FOR ALL
+    USING      (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+    WITH CHECK (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
+```
+
+> **Read this before splitting a policy in two: multiple permissive policies are
+> combined with OR, not AND.** Adding `employee_read` next to `employee_write`
+> *widens* what SELECT can see (`FOR ALL` also applies to SELECT, and the two
+> `USING` clauses are OR'd) — it does not restrict it. That is what makes the
+> pair above correct: reads see shared + own, while writes are confined to own by
+> `employee_write`'s `WITH CHECK`, which `employee_read` cannot relax because a
+> `FOR SELECT` policy has no `WITH CHECK`. If you want a policy that genuinely
+> narrows, that is `CREATE POLICY ... AS RESTRICTIVE`. A single policy carrying
+> both `USING` and `WITH CHECK` avoids the question entirely and is the simpler
+> choice when one predicate covers reads.
+
+The corollary is a request with **no tenant at all** — a public read, a warm-up
+job, a health probe — which must still see the shared rows. Configure the reader
+with a stand-in value so those connections are bound rather than left to chance
+(see §4).
+
+### 3. Application side (YAML only)
 
 ```yaml
 readeasy:
@@ -373,10 +421,50 @@ The two-argument `JdbcGeneralReader(dataSource, settingName)` constructor wraps 
 A pooled connection therefore never carries one request's tenant into the next.
 Omit the second constructor argument and the reader behaves exactly as before - RLS is opt-in per reader.
 
-By default, acquiring a connection with no tenant in scope throws (fail loud).
-`RlsDataSource` can be constructed with `failWhenTenantMissing=false` for jobs that legitimately run without a tenant; the database policy still fails closed.
+`JdbcGeneralUpdater` has the same constructors for RLS-enforced writes.
 
-`JdbcGeneralUpdater` has the same two-argument constructor for RLS-enforced writes.
+### 4. Requests with no tenant in scope
+
+`RlsSettings.missingTenant` decides what happens when a connection is acquired
+and `TenantContext` is empty:
+
+| `MissingTenant` | behaviour |
+|---|---|
+| `FAIL` (default) | throw `IllegalStateException`. A tenant-less checkout is usually a wiring mistake, and the policy failing closed hides it. |
+| `BIND` | bind `missingTenantValue` (default `''`) and wrap the connection exactly as a tenant-scoped one, so the reset-on-close guarantee holds and the session state is the same on every checkout. |
+
+`BIND` is the mode for the shared-rows model in §2: the predicate's own-tenant
+branch matches nothing, the `tenant_id IS NULL` branch matches, and the caller
+gets the shared rows and only those. Select it from YAML with a third
+constructor argument:
+
+```yaml
+      constructorArgs:
+        - typeFqcn: javax.sql.DataSource
+          beanName: dataSource
+        - typeFqcn: java.lang.String
+          val: app.tenant_id
+        - typeFqcn: java.lang.String
+          val: ""                         # presence of this arg selects BIND
+```
+
+or in code:
+
+```java
+new JdbcGeneralReader(dataSource, "app.tenant_id", "");
+
+new RlsDataSource(dataSource,
+        new RlsSettings("app.tenant_id", MissingTenant.BIND, "", TenantContext::getTenantId));
+```
+
+**Upgrading from `failWhenTenantMissing = false`.** That flag is deprecated and
+now maps to `BIND("")`. It used to hand back an *unbound* connection, which read
+back as `NULL` on a connection the pool had never used and `''` on one it had —
+so under a casting policy the same tenant-less request succeeded against a cold
+pool and failed against a warm one. It is now deterministic, which means a
+`::uuid` policy without `nullif` will fail *every* time instead of
+intermittently. **Adopt the `nullif(current_setting(...), '')::uuid` form from §1
+in the same change as the version bump**, not as a follow-up.
 
 ## Working with Different Databases
 

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralReader.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralReader.java
@@ -40,6 +40,18 @@ public class JdbcGeneralReader implements GeneralReader<JdbcOperation, Object> {
         this(new RlsDataSource(dataSource, rlsSettingName));
     }
 
+    /**
+     * As above, but requests with no tenant in scope bind {@code missingTenantValue}
+     * instead of failing - the mode for tables whose rows are shared across all
+     * tenants (typically {@code tenant_id IS NULL}) and must stay readable
+     * without one. Wire it from YAML/InitDTO config as a third constructor arg
+     * (beanName: dataSource, val: app.tenant_id, val: ""); its presence is what
+     * selects {@link lazydevs.persistence.jdbc.rls.MissingTenant#BIND}.
+     */
+    public JdbcGeneralReader(DataSource dataSource, String rlsSettingName, String missingTenantValue){
+        this(new RlsDataSource(dataSource, rlsSettingName, missingTenantValue));
+    }
+
     @Override
     public Map<String, Object> findOne(JdbcOperation query, Map<String, Object> params) {
         List<Map<String, Object>> response = (List<Map<String, Object>>) getResultSetMapper().findAllRowsAsMap(query.getNativeSQL(), query.getParamsAsArr());

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralUpdater.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/general/JdbcGeneralUpdater.java
@@ -43,6 +43,17 @@ public class JdbcGeneralUpdater implements GeneralUpdater<JdbcOperation, JdbcOpe
         this(new RlsDataSource(dataSource, rlsSettingName));
     }
 
+    /**
+     * As above, but writes with no tenant in scope bind {@code missingTenantValue}
+     * instead of failing. Note that this widens nothing by itself: what a
+     * tenant-less session may write is still whatever the policy's WITH CHECK
+     * clause allows, which for shared rows should be narrower than its USING
+     * clause.
+     */
+    public JdbcGeneralUpdater(DataSource dataSource, String rlsSettingName, String missingTenantValue){
+        this(new RlsDataSource(dataSource, rlsSettingName, missingTenantValue));
+    }
+
     @Override
     public Map<String, Object> replace(Map<String, Object> row, JdbcOperation jdbcOperation) {
         executeUpdate(row, jdbcOperation);

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/MissingTenant.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/MissingTenant.java
@@ -1,0 +1,45 @@
+package lazydevs.persistence.jdbc.rls;
+
+/**
+ * What {@link RlsDataSource} does when a connection is acquired with no tenant
+ * in scope.
+ *
+ * <p>There are exactly two sensible answers, and neither of them is "hand back
+ * an unbound connection". A PostgreSQL custom GUC cannot be returned to the
+ * <em>unset</em> state once it has been written in a session - neither
+ * {@code set_config(name, NULL, false)} nor {@code RESET name} nor
+ * {@code DISCARD ALL} does it; all three leave the empty string. So a
+ * connection that is deliberately left unbound reads back as {@code NULL} the
+ * first time it is checked out of the pool and as {@code ''} every time after,
+ * which makes the same tenant-less request behave differently depending on how
+ * warm the pool is. That was the behaviour of {@code failWhenTenantMissing =
+ * false} before this enum existed, and it is why the option is now expressed as
+ * a choice between failing and binding.</p>
+ *
+ * @author Abhijeet Rai
+ */
+public enum MissingTenant {
+
+    /**
+     * Throw. The default: a tenant-less checkout is usually a wiring mistake,
+     * and the database policy failing closed hides it rather than reporting it.
+     */
+    FAIL,
+
+    /**
+     * Bind {@link RlsSettings#getMissingTenantValue()} (the empty string unless
+     * configured otherwise) and wrap the connection exactly as a tenant-scoped
+     * one, so the reset-on-close guarantee still holds and the session state is
+     * the same on every checkout.
+     *
+     * <p>This is the mode for a request that legitimately has no tenant and must
+     * still see rows shared across all of them - see the shared-rows section of
+     * the read-easy README. Write the policy so that an empty tenant matches
+     * nothing rather than raising:</p>
+     * <pre>{@code
+     * using (tenant_id is null                                            -- shared
+     *        or tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid)
+     * }</pre>
+     */
+    BIND
+}

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsDataSource.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsDataSource.java
@@ -22,15 +22,20 @@ import java.util.logging.Logger;
  * open across a streamed export) acquires and closes connections through the
  * DataSource, decorating at this seam covers all of them.</p>
  *
- * <p>When no tenant is in scope, the default is to throw (fail loud); with
- * {@code failWhenTenantMissing=false} the raw connection is returned unbound and
- * the database policy itself fails closed (an unset variable matches no rows).</p>
+ * <p>When no tenant is in scope the behaviour is {@link RlsSettings#getMissingTenant()}:
+ * {@link MissingTenant#FAIL} (the default) throws, and {@link MissingTenant#BIND}
+ * binds a configured stand-in value - the empty string unless set otherwise -
+ * through the same bind-and-reset path, so the session state a policy sees does
+ * not depend on how warm the pool is.</p>
  *
- * <p>The DB side (policies, roles) is owned by your SQL migrations, e.g.:</p>
+ * <p>The DB side (policies, roles) is owned by your SQL migrations. Write the
+ * predicate so an empty tenant matches nothing rather than raising - a bare
+ * {@code ''::uuid} is an error, and {@code ''} is what a released connection is
+ * reset to:</p>
  * <pre>{@code
  * ALTER TABLE employee ENABLE ROW LEVEL SECURITY;
  * CREATE POLICY employee_tenant_isolation ON employee
- *     USING (tenant_id = current_setting('app.tenant_id', true)::uuid);
+ *     USING (tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid);
  * }</pre>
  *
  * @author Abhijeet Rai
@@ -58,6 +63,15 @@ public class RlsDataSource implements DataSource {
         this(delegate, new RlsSettings(settingName));
     }
 
+    /**
+     * Convenience constructor for config-driven wiring that must also serve
+     * requests with no tenant: supplying {@code missingTenantValue} selects
+     * {@link MissingTenant#BIND} and binds that value when the tenant is absent.
+     */
+    public RlsDataSource(DataSource delegate, String settingName, String missingTenantValue) {
+        this(delegate, new RlsSettings(settingName, missingTenantValue));
+    }
+
     @Override
     public Connection getConnection() throws SQLException {
         return bindTenant(delegate.getConnection());
@@ -71,13 +85,16 @@ public class RlsDataSource implements DataSource {
     private Connection bindTenant(Connection connection) throws SQLException {
         String tenantId = settings.getTenantSupplier().get();
         if (null == tenantId || tenantId.isEmpty()) {
-            if (settings.isFailWhenTenantMissing()) {
+            if (MissingTenant.FAIL == settings.getMissingTenant()) {
                 closeQuietly(connection);
                 throw new IllegalStateException("No tenant in scope while acquiring an RLS-bound connection ("
-                        + settings.getSettingName() + "). Set TenantContext (or configure failWhenTenantMissing=false).");
+                        + settings.getSettingName() + "). Set TenantContext (or configure MissingTenant.BIND).");
             }
-            log.debug("No tenant in scope; returning connection without setting {}", settings.getSettingName());
-            return connection;
+            // Bound, not skipped: an unbound connection reads back as NULL when
+            // fresh and as '' once recycled, and a policy cannot be written
+            // against both.
+            tenantId = settings.getMissingTenantValue();
+            log.debug("No tenant in scope; binding {} = '{}'", settings.getSettingName(), tenantId);
         }
         try {
             TenantBoundConnection.setConfig(connection, settings.getSettingName(), tenantId);

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsSettings.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/RlsSettings.java
@@ -21,6 +21,14 @@ public class RlsSettings {
 
     public static final String DEFAULT_SETTING_NAME = "app.tenant_id";
 
+    /**
+     * What {@link MissingTenant#BIND} binds unless told otherwise. The empty
+     * string is the right default because it is also what a released connection
+     * is reset to, so a tenant-less checkout and a recycled connection present
+     * the policy with identical session state.
+     */
+    public static final String DEFAULT_MISSING_TENANT_VALUE = "";
+
     /** Custom GUCs require a dot-separated two-part name. */
     private static final Pattern SETTING_NAME_PATTERN =
             Pattern.compile("[A-Za-z_][A-Za-z0-9_]*\\.[A-Za-z_][A-Za-z0-9_]*");
@@ -28,34 +36,75 @@ public class RlsSettings {
     /** The PostgreSQL session variable the RLS policy reads. */
     private final String settingName;
 
-    /**
-     * When true (the default), acquiring a connection with no tenant in scope
-     * throws instead of returning an unbound connection. The database policy
-     * fails closed either way; this makes the mistake loud instead of silent.
-     */
-    private final boolean failWhenTenantMissing;
+    /** What to do when a connection is acquired with no tenant in scope. */
+    private final MissingTenant missingTenant;
+
+    /** The value bound under {@link MissingTenant#BIND}; ignored under FAIL. */
+    private final String missingTenantValue;
 
     /** Where the current tenant comes from. Defaults to {@link TenantContext#getTenantId()}. */
     @ToString.Exclude
     private final Supplier<String> tenantSupplier;
 
-    public RlsSettings(String settingName, boolean failWhenTenantMissing, Supplier<String> tenantSupplier) {
+    public RlsSettings(String settingName, MissingTenant missingTenant, String missingTenantValue,
+                       Supplier<String> tenantSupplier) {
         if (null == settingName || !SETTING_NAME_PATTERN.matcher(settingName).matches()) {
             throw new IllegalArgumentException("RLS settingName must be a two-part custom GUC name like 'app.tenant_id', but was: " + settingName);
+        }
+        if (null == missingTenant) {
+            throw new IllegalArgumentException("missingTenant is required");
+        }
+        if (null == missingTenantValue) {
+            throw new IllegalArgumentException("missingTenantValue is required (use \"\" for the default)");
         }
         if (null == tenantSupplier) {
             throw new IllegalArgumentException("tenantSupplier is required");
         }
         this.settingName = settingName;
-        this.failWhenTenantMissing = failWhenTenantMissing;
+        this.missingTenant = missingTenant;
+        this.missingTenantValue = missingTenantValue;
         this.tenantSupplier = tenantSupplier;
     }
 
+    public RlsSettings(String settingName, MissingTenant missingTenant, String missingTenantValue) {
+        this(settingName, missingTenant, missingTenantValue, TenantContext::getTenantId);
+    }
+
+    /** Binds {@code missingTenantValue} when no tenant is in scope. */
+    public RlsSettings(String settingName, String missingTenantValue) {
+        this(settingName, MissingTenant.BIND, missingTenantValue);
+    }
+
+    /** Fails loud when no tenant is in scope. */
     public RlsSettings(String settingName) {
-        this(settingName, true, TenantContext::getTenantId);
+        this(settingName, MissingTenant.FAIL, DEFAULT_MISSING_TENANT_VALUE, TenantContext::getTenantId);
+    }
+
+    /**
+     * @deprecated {@code failWhenTenantMissing = false} used to hand back an
+     * <em>unbound</em> connection, whose session state then depended on whether
+     * that pooled connection had been used before - see {@link MissingTenant}.
+     * It now maps to {@code BIND("")}, which is deterministic. Migrate to
+     * {@link #RlsSettings(String, MissingTenant, String, Supplier)} and, if your
+     * policy casts the setting, to the {@code nullif(..., '')::uuid} form.
+     */
+    @Deprecated
+    public RlsSettings(String settingName, boolean failWhenTenantMissing, Supplier<String> tenantSupplier) {
+        this(settingName,
+                failWhenTenantMissing ? MissingTenant.FAIL : MissingTenant.BIND,
+                DEFAULT_MISSING_TENANT_VALUE,
+                tenantSupplier);
     }
 
     public static RlsSettings defaults() {
         return new RlsSettings(DEFAULT_SETTING_NAME);
+    }
+
+    /**
+     * @deprecated use {@link #getMissingTenant()}.
+     */
+    @Deprecated
+    public boolean isFailWhenTenantMissing() {
+        return MissingTenant.FAIL == missingTenant;
     }
 }

--- a/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/TenantBoundConnection.java
+++ b/persistence-impls/simple-jdbc-persistence/src/main/java/lazydevs/persistence/jdbc/rls/TenantBoundConnection.java
@@ -62,8 +62,13 @@ public final class TenantBoundConnection implements InvocationHandler {
             return;
         }
         try {
-            // Empty value fails closed: a policy casting current_setting(...) to uuid
-            // errors loudly, and an equality check matches no tenant.
+            // '' rather than "unset": PostgreSQL offers no way back to unset for a
+            // custom GUC once it has been written (set_config(name, NULL),
+            // RESET and DISCARD ALL all leave ''), so '' IS the cleared state
+            // and every checkout after the first one sees it. An equality check
+            // against '' matches no tenant; a policy that CASTS the setting must
+            // therefore be written nullif(current_setting(...), '')::uuid,
+            // because a bare ''::uuid raises instead of matching nothing.
             setConfig(delegate, settingName, "");
         } catch (SQLException resetFailure) {
             try {

--- a/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsDataSourceTest.java
+++ b/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsDataSourceTest.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -116,14 +117,66 @@ class RlsDataSourceTest {
     }
 
     @Test
-    void missingTenantPassesThroughWhenConfiguredLenient() throws SQLException {
+    void missingTenantBindsTheStandInValueAndStillResetsOnClose() throws SQLException {
         FakeDb db = new FakeDb();
         RlsDataSource rls = new RlsDataSource(db.dataSource(),
-                new RlsSettings("app.tenant_id", false, TenantContext::getTenantId));
+                new RlsSettings("app.tenant_id", MissingTenant.BIND, ""));
         Connection connection = rls.getConnection();
-        assertTrue(db.events.isEmpty(), "no set_config expected without a tenant");
+        assertEquals(List.of("app.tenant_id="), db.events, "the stand-in must be bound, not skipped");
         connection.close();
-        assertEquals(List.of("connection-closed"), db.events);
+        assertEquals(List.of("app.tenant_id=", "app.tenant_id=", "connection-closed"), db.events);
+    }
+
+    @Test
+    void missingTenantCanBindACustomStandInValue() throws SQLException {
+        FakeDb db = new FakeDb();
+        Connection connection = new RlsDataSource(db.dataSource(), "app.tenant_id", "~pool").getConnection();
+        assertEquals(List.of("app.tenant_id=~pool"), db.events);
+        connection.close();
+        assertEquals(List.of("app.tenant_id=~pool", "app.tenant_id=", "connection-closed"), db.events);
+    }
+
+    /**
+     * The regression this whole change exists for. Before it, the second
+     * checkout recorded NO set_config at all, leaving the connection carrying
+     * the '' written by the first one's reset - which a policy casting the
+     * setting to uuid rejects outright, while a never-used connection (NULL)
+     * would have been fine. Same request, two outcomes, chosen by pool warmth.
+     */
+    @Test
+    void tenantLessCheckoutAfterATenantScopedOneBindsRatherThanInheritingSessionState() throws SQLException {
+        FakeDb db = new FakeDb();
+        RlsDataSource rls = new RlsDataSource(db.dataSource(),
+                new RlsSettings("app.tenant_id", MissingTenant.BIND, ""));
+
+        TenantContext.setTenantId("tenant-1");
+        rls.getConnection().close();
+
+        // FakeDb models ONE physical connection, and its close() is real rather
+        // than a return-to-pool, so clear the flag to represent the pool handing
+        // that same connection back. This is the whole scenario: the second
+        // checkout runs on a connection that has already been bound and reset.
+        db.closed = false;
+
+        TenantContext.reset();
+        rls.getConnection().close();
+
+        assertEquals(List.of(
+                "app.tenant_id=tenant-1", "app.tenant_id=", "connection-closed",
+                "app.tenant_id=", "app.tenant_id=", "connection-closed"), db.events);
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    void legacyLenientFlagMapsToBindingTheEmptyString() throws SQLException {
+        FakeDb db = new FakeDb();
+        RlsSettings settings = new RlsSettings("app.tenant_id", false, TenantContext::getTenantId);
+        assertEquals(MissingTenant.BIND, settings.getMissingTenant());
+        assertFalse(settings.isFailWhenTenantMissing());
+
+        Connection connection = new RlsDataSource(db.dataSource(), settings).getConnection();
+        assertEquals(List.of("app.tenant_id="), db.events);
+        connection.close();
     }
 
     @Test

--- a/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsEndToEndTest.java
+++ b/persistence-impls/simple-jdbc-persistence/src/test/java/lazydevs/persistence/jdbc/rls/RlsEndToEndTest.java
@@ -17,6 +17,7 @@ import java.util.List;
 import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**
  * Proves the full wiring through {@link JdbcGeneralReader}: the tenant GUC is
@@ -25,6 +26,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
  * exports. H2 stands in for PostgreSQL via a {@code SET_CONFIG} alias that
  * records invocations; the actual row filtering is PostgreSQL's job and is
  * covered by the policy, not this test.
+ *
+ * <p>Scope, stated plainly: H2 has neither row-level security nor PostgreSQL's
+ * {@code ''::uuid} cast semantics, so nothing here can demonstrate the error a
+ * casting policy raises against a released connection. What these tests DO
+ * pin down is the binding sequence - that a tenant-less checkout binds a value
+ * of its own rather than inheriting whatever the previous request left behind -
+ * which is the library-side half of that bug. The cast hazard itself is covered
+ * by documentation ({@link TenantBoundConnection} and the read-easy README).</p>
  */
 public class RlsEndToEndTest {
 
@@ -85,6 +94,37 @@ public class RlsEndToEndTest {
             assertEquals(List.of("app.tenant_id=t1"), SET_CONFIG_CALLS);
         }
         assertEquals(List.of("app.tenant_id=t1", "app.tenant_id="), SET_CONFIG_CALLS);
+    }
+
+    /**
+     * The pool-reuse repro from the issue, as far as H2 can express it. Before
+     * MissingTenant existed, the second read recorded no set_config at all and
+     * ran against the '' left by the first read's reset; now it binds its own
+     * stand-in, so the session state is identical whether or not a tenant-scoped
+     * request came first.
+     */
+    @Test
+    void tenantLessReadBindsAStandInRatherThanInheritingTheReleasedSessionState() {
+        JdbcGeneralReader reader = new JdbcGeneralReader(h2, "app.tenant_id", "");
+        JdbcOperation query = JdbcOperation.nativeSql("select * from employee order by id");
+
+        TenantContext.setTenantId("t1");
+        reader.findAll(query, Map.of());
+
+        TenantContext.reset();
+        reader.findAll(query, Map.of());
+
+        assertEquals(List.of(
+                "app.tenant_id=t1", "app.tenant_id=",
+                "app.tenant_id=", "app.tenant_id="), SET_CONFIG_CALLS);
+    }
+
+    @Test
+    void tenantLessReadStillThrowsUnderTheDefaultFailMode() {
+        JdbcGeneralReader reader = new JdbcGeneralReader(h2, "app.tenant_id");
+        TenantContext.reset();
+        assertThrows(IllegalStateException.class, () -> reader.findAll(
+                JdbcOperation.nativeSql("select * from employee"), Map.of()));
     }
 
     @Test


### PR DESCRIPTION
Closes #20, in the shape agreed there.

## What changes

`RlsDataSource` had two answers for a checkout with no tenant in scope, and neither served a schema whose rows can be shared across tenants:

| before | behaviour |
|---|---|
| `failWhenTenantMissing = true` (default, and the only value reachable from YAML) | throws |
| `failWhenTenantMissing = false` | returns the connection **unbound** |

The second is pool-state dependent, because a PostgreSQL custom GUC cannot be returned to the unset state once written — `set_config(name, NULL, false)`, `RESET name` and `DISCARD ALL` all leave `''`. So an unbound connection reads back as `NULL` on its first checkout and `''` on every one after. Under the `current_setting(...)::uuid` policy this repo's own README and javadoc recommended, that is the difference between matching no rows and `ERROR: invalid input syntax for type uuid: ""` — the same request succeeding against a cold pool and 500ing against a warm one.

Replaced with an explicit policy:

```java
public enum MissingTenant { FAIL, BIND }
```

| after | behaviour |
|---|---|
| `MissingTenant.FAIL` | throw — unchanged default |
| `MissingTenant.BIND` | bind `missingTenantValue` (default `""`) through the same bind-and-reset path, so session state is identical on every checkout |

`BIND` is what the shared-rows model needs: with `tenant_id IS NULL OR tenant_id = nullif(current_setting('app.tenant_id', true), '')::uuid`, a tenant-less caller sees the shared rows and only those.

## Config reachability

Previously nothing but `failWhenTenantMissing = true` could be selected through `readeasy.generalReaders` YAML. A third constructor argument now selects `BIND`, on both the reader and the updater:

```yaml
constructorArgs:
  - typeFqcn: javax.sql.DataSource
    beanName: dataSource
  - typeFqcn: java.lang.String
    val: app.tenant_id
  - typeFqcn: java.lang.String
    val: ""            # presence of this arg selects BIND
```

## Compatibility

Source-compatible. The deprecated boolean constructor maps `false` to `BIND("")`, and `isFailWhenTenantMissing()` is kept as a deprecated accessor.

**Behaviour does change for anyone on the lenient flag with a casting policy:** they move from an intermittent error to a deterministic one. That is the point, but their cold-pool smoke test passes today and will fail immediately after the bump, so the README says plainly that adopting the `nullif(...)` form is part of the upgrade rather than a follow-up. Worth repeating in the release notes.

## Docs

- Canonical policy is now `nullif(current_setting('app.tenant_id', true), '')::uuid`, with a three-state table (never written / bound / released) showing why the `nullif` is not optional. This also corrects the old line "if the variable is not set, `current_setting(..., true)` returns NULL and the policy matches no rows", which is only true on a connection the pool has never used.
- New shared-rows section, **including the warning that permissive policies are OR'd** — a `FOR SELECT` policy added next to `FOR ALL` widens SELECT rather than narrowing it, which is exactly the mistake the split-policy guidance would otherwise invite. `AS RESTRICTIVE` is named as the thing people actually reach for when they want narrowing.
- `MissingTenant` table, YAML and code wiring, and the upgrade note.

I ran the documented policy pair against PostgreSQL 16 as a non-owning, `NOBYPASSRLS` role before writing that section, rather than reasoning about it:

```
tenant t1:  SELECT                     -> own + shared (2 rows)     ✓
            UPDATE the shared row      -> UPDATE 0                  ✓
            INSERT a shared row        -> WITH CHECK violation      ✓
            UPDATE own row             -> UPDATE 1                  ✓
tenant-less (BIND "")
            SELECT                     -> shared only (1 row)       ✓
```

## Tests

The pool-reuse repro at both levels:

- `RlsDataSourceTest.tenantLessCheckoutAfterATenantScopedOneBindsRatherThanInheritingSessionState` — asserts the recorded `set_config` sequence when a tenant-less checkout follows a tenant-scoped one on the same physical connection. Before this change the second checkout recorded nothing at all.
- `RlsEndToEndTest.tenantLessReadBindsAStandInRatherThanInheritingTheReleasedSessionState` — the same thing through `JdbcGeneralReader`, using the existing H2 `set_config` alias harness.
- Plus `BIND` with a custom stand-in value, `FAIL` still throwing, and the deprecated flag mapping.

**Scope stated in the class javadoc rather than left implicit:** H2 has neither row-level security nor PostgreSQL's `''::uuid` cast semantics, so these tests pin down the *binding sequence* — the library-side half of the bug — and not the cast behaviour, which stays documentation-covered. If you would rather have the cast itself under test, that needs a Testcontainers PostgreSQL case and I am happy to add it in a follow-up.

`mvn -pl persistence-impls/simple-jdbc-persistence -am test` is green: 11 in `RlsDataSourceTest`, 5 in `RlsEndToEndTest`, no other module affected.

## Not in this PR

Multiple GUCs per checkout (actor/audit variables) — agreed on the issue to keep it separate. I will open it with the use case written out.
